### PR TITLE
fix: get key in case of unique violation

### DIFF
--- a/src/core/datakey/create.rs
+++ b/src/core/datakey/create.rs
@@ -33,7 +33,7 @@ pub async fn generate_and_create_data_key(
         err
     })?;
 
-    let data_key = db.insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()?;
     Ok(DataKeyCreateResponse {
         key_version: data_key.version,
         identifier: req.identifier,

--- a/src/core/datakey/rotate.rs
+++ b/src/core/datakey/rotate.rs
@@ -38,7 +38,7 @@ pub async fn generate_and_rotate_data_key(
         err
     })?;
 
-    let data_key = db.insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()?;
     Ok(DataKeyCreateResponse {
         key_version: data_key.version,
         identifier: req.identifier,

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -38,7 +38,7 @@ pub async fn transfer_data_key(
         err
     })?;
 
-    let data_key = db.insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()?;
 
     Ok(DataKeyCreateResponse {
         identifier: req.identifier,


### PR DESCRIPTION
- Get key in case of Unique violation

How did you test it

- Create Key more than once, It should not throw unique violation

```
curl --location 'http://localhost:5000/key/create' \
--header 'Content-Type: application/json' \
--data '{
    "data_identifier": "User",
    "key_identifier": "firstkey12"
}'
```