### PR TITLE
fix: change rsa key size to 2048

### DIFF
--- a/scripts/tls/gen_certs.sh
+++ b/scripts/tls/gen_certs.sh
@@ -34,7 +34,7 @@ else
 fi
 
 function gen_ca() {
-  openssl genrsa -out ca_key.pem 4096
+  openssl genrsa -out ca_key.pem 2048
   openssl req -new -x509 -days 3650 -key ca_key.pem \
     -subj "${CA_SUBJECT}" -out ca_cert.pem
 }
@@ -50,7 +50,7 @@ function gen_client_key() {
 function gen_rsa_sha256() {
   gen_ca_if_non_existent
 
-  openssl req -newkey rsa:4096 -nodes -sha256 -keyout rsa_sha256_key.pem \
+  openssl req -newkey rsa:2048 -nodes -sha256 -keyout rsa_sha256_key.pem \
     -subj "${SUBJECT}" -out server.csr
 
   openssl x509 -req -sha256 -extfile <(printf "subjectAltName=${ALT}") -days 3650 \


### PR DESCRIPTION
This commit changes the RSA Key for SSL certificates to 2048 bits.

Reason
- 2048 bits keys are considered as norm and the compute power 4096 bits takes considered as not worth it
- AWS KMS encryption only supports till 4Kb which is around 4096 bytes and client certificates for 4096bits RSA produces 8Kb file which cannot be used with KMS Encryption

https://stackoverflow.com/questions/589834/what-rsa-key-length-should-i-use-for-my-ssl-certificates 