### PR TITLE
feat(custodian): add support for authorization for accessing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +561,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,9 +644,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -679,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +756,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64 0.22.1",
+ "blake3",
  "cargo_metadata",
  "config",
  "diesel",
@@ -2353,6 +2388,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ rustc-hash = "1.1.0"
 rayon = "1.10.0"
 once_cell = "1.19.0"
 hyper = "1.3.1"
+blake3 = "1.5.4"
 
 [build-dependencies]
 cargo_metadata = "0.18.1"

--- a/config/development.toml
+++ b/config/development.toml
@@ -24,4 +24,5 @@ log_format = "console"
 
 [secrets]
 master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
-
+access_token = "secret123"
+hash_context = "keymanager:hyperswitch"

--- a/migrations/2024-09-30-125631_add-token-column/down.sql
+++ b/migrations/2024-09-30-125631_add-token-column/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE data_key_store DROP COLUMN IF EXISTS token;

--- a/migrations/2024-09-30-125631_add-token-column/up.sql
+++ b/migrations/2024-09-30-125631_add-token-column/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TABLE data_key_store ADD COLUMN IF NOT EXISTS token VARCHAR(255);

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,8 @@ pub struct Secrets {
     pub master_key: GcmAes256,
     #[cfg(feature = "aws")]
     pub kms_config: AwsKmsConfig,
+    pub access_token: masking::Secret<String>,
+    pub hash_context: masking::Secret<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/core/crypto.rs
+++ b/src/core/crypto.rs
@@ -1,6 +1,7 @@
 mod crux;
 mod decryption;
 mod encryption;
+pub(crate) mod custodian;
 
 pub use crux::*;
 

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -116,7 +116,8 @@ impl DataEncrypter<EncryptedDataGroup> for DecryptedDataGroup {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            !identifier.is_entity()
+                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
             errors::CryptoError::AuthenticationFailed
         );
 

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -152,7 +152,7 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            stored_tokens.all(|t| t.is_none() || t.eq(&provided_token)),
+            !identifier.is_entity() || stored_tokens.all(|t| t.is_none() || t.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -194,7 +194,8 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            !identifier.is_entity()
+                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -224,7 +225,8 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            !identifier.is_entity()
+                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
             errors::CryptoError::AuthenticationFailed
         );
 

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -1,3 +1,4 @@
+use error_stack::ensure;
 use masking::PeekInterface;
 use rayon::prelude::*;
 
@@ -14,6 +15,8 @@ use crate::{
         Identifier, Key,
     },
 };
+
+use super::custodian::Custodian;
 
 #[async_trait::async_trait]
 pub trait KeyEncrypter<ToType> {
@@ -47,7 +50,7 @@ impl KeyEncrypter<DataKeyNew> for Key {
                 time::OffsetDateTime::now_utc().date(),
                 time::OffsetDateTime::now_utc().time(),
             ),
-            token: self.token
+            token: self.token,
         })
     }
 }
@@ -72,7 +75,7 @@ impl KeyDecrypter<Key> for DataKey {
             version: self.version,
             key: decrypted_key.into(),
             source,
-            token: self.token
+            token: self.token,
         })
     }
 }
@@ -83,6 +86,7 @@ pub trait DataEncrypter<ToType> {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<ToType, errors::CryptoError>;
 }
 
@@ -92,6 +96,7 @@ pub trait DataDecrypter<ToType> {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<ToType, errors::CryptoError>;
 }
 
@@ -101,10 +106,19 @@ impl DataEncrypter<EncryptedDataGroup> for DecryptedDataGroup {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<EncryptedDataGroup, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
         let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
         let key = GcmAes256::new(decrypted_key.key)?;
+
+        let stored_token = decrypted_key.token;
+        let provided_token = custodian.into_access_token(state);
+
+        ensure!(
+            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            errors::CryptoError::AuthenticationFailed
+        );
 
         state.thread_pool.install(|| {
             self.0
@@ -127,11 +141,20 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<DecryptedDataGroup, errors::CryptoError> {
         let version = FxHashSet::from_iter(self.0.values().map(|d| d.version));
         let decrypted_keys = Key::get_multiple_keys(state, identifier, version)
             .await
             .switch()?;
+
+        let mut stored_tokens = decrypted_keys.values().map(|k| &k.token);
+        let provided_token = custodian.into_access_token(state);
+
+        ensure!(
+            stored_tokens.all(|t| t.is_none() || t.eq(&provided_token)),
+            errors::CryptoError::AuthenticationFailed
+        );
 
         state.thread_pool.install(|| {
             self
@@ -162,9 +185,19 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<EncryptedData, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
         let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+
+        let stored_token = decrypted_key.token;
+        let provided_token = custodian.into_access_token(state);
+
+        ensure!(
+            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            errors::CryptoError::AuthenticationFailed
+        );
+
         let key = GcmAes256::new(decrypted_key.key)?;
 
         let encrypted_data = key.encrypt(self.inner())?;
@@ -182,9 +215,19 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<DecryptedData, errors::CryptoError> {
         let version = self.version;
         let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+
+        let stored_token = decrypted_key.token;
+        let provided_token = custodian.into_access_token(state);
+
+        ensure!(
+            stored_token.is_none() || (stored_token.eq(&provided_token)),
+            errors::CryptoError::AuthenticationFailed
+        );
+
         let key = GcmAes256::new(decrypted_key.key)?;
 
         let decrypted_data = key.decrypt(self.inner())?;

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -116,8 +116,7 @@ impl DataEncrypter<EncryptedDataGroup> for DecryptedDataGroup {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            !identifier.is_entity()
-                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
+            !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -153,7 +152,7 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            !identifier.is_entity() || stored_tokens.all(|t| t.is_none() || t.eq(&provided_token)),
+            !identifier.is_entity() || stored_tokens.all(|t| t.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -195,8 +194,7 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            !identifier.is_entity()
-                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
+            !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -226,8 +224,7 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         let provided_token = custodian.into_access_token(state);
 
         ensure!(
-            !identifier.is_entity()
-                || (stored_token.is_none() || (stored_token.eq(&provided_token))),
+            !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
         );
 

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -47,6 +47,7 @@ impl KeyEncrypter<DataKeyNew> for Key {
                 time::OffsetDateTime::now_utc().date(),
                 time::OffsetDateTime::now_utc().time(),
             ),
+            token: self.token
         })
     }
 }
@@ -71,6 +72,7 @@ impl KeyDecrypter<Key> for DataKey {
             version: self.version,
             key: decrypted_key.into(),
             source,
+            token: self.token
         })
     }
 }

--- a/src/core/crypto/custodian.rs
+++ b/src/core/crypto/custodian.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request;
+use base64::Engine;
+use error_stack::{ensure, ResultExt};
+use hyper::header;
+use masking::{PeekInterface, Secret, StrongSecret};
+
+use crate::app::AppState;
+use crate::consts::base64::BASE64_ENGINE;
+use crate::errors::{ApiErrorContainer, CustomResult, ParsingError, SwitchError, ToContainerError};
+
+pub struct Custodian {
+    pub keys: Option<(StrongSecret<String>, StrongSecret<String>)>,
+}
+
+impl Custodian {
+    fn new(keys: Option<(String, String)>) -> Self {
+        let keys = keys.map(|(key1, key2)| (StrongSecret::new(key1), StrongSecret::new(key2)));
+        Self { keys }
+    }
+
+    pub fn into_access_token(self, state: Arc<AppState>) -> Option<StrongSecret<String>> {
+        self.keys
+            .map(|(x, y)| format!("{}:{}", x.peek(), y.peek()))
+            .map(|key| crate::crypto::blake3::Blake3::hash(&state, Secret::new(key)))
+            .map(|token| hex::encode(&token))
+            .map(StrongSecret::new)
+    }
+}
+
+#[axum::async_trait]
+impl FromRequestParts<Arc<AppState>> for Custodian {
+    type Rejection = ApiErrorContainer;
+    async fn from_request_parts(
+        parts: &mut request::Parts,
+        _state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .map(extract_credential)
+            .transpose()
+            .switch()
+            .to_container_error()
+            .map(Self::new)
+    }
+}
+
+fn extract_credential(
+    header: &header::HeaderValue,
+) -> CustomResult<(String, String), ParsingError> {
+    let header = header.to_str().change_context(ParsingError::ParsingFailed(
+        "Failed while converting header to string".to_string(),
+    ))?;
+
+    let credential = header
+        .strip_prefix("Basic ")
+        .ok_or(ParsingError::ParsingFailed(
+            "Authorization scheme is not basic".to_string(),
+        ))?;
+    let credential = credential.trim();
+    let credential =
+        BASE64_ENGINE
+            .decode(credential)
+            .change_context(ParsingError::DecodingFailed(
+                "Failed while decoding base64".to_string(),
+            ))?;
+    let credential = String::from_utf8(credential).change_context(ParsingError::DecodingFailed(
+        "Failed while converting base64 to utf8".to_string(),
+    ))?;
+    let mut parts = credential.split(':');
+    let key1 = parts.next().ok_or(ParsingError::ParsingFailed(
+        "Failed while extracting key1 from credential".to_string(),
+    ))?;
+    let key2 = parts.next().ok_or(ParsingError::ParsingFailed(
+        "Failed while extracting key2 from credential".to_string(),
+    ))?;
+
+    ensure!(
+        parts.next().is_none(),
+        ParsingError::ParsingFailed("Credential has more than 2 parts".to_string())
+    );
+
+    Ok((key1.to_string(), key2.to_string()))
+}

--- a/src/core/crypto/custodian.rs
+++ b/src/core/crypto/custodian.rs
@@ -21,11 +21,11 @@ impl Custodian {
         Self { keys }
     }
 
-    pub fn into_access_token(self, state: Arc<AppState>) -> Option<StrongSecret<String>> {
+    pub fn into_access_token(self, state: &AppState) -> Option<StrongSecret<String>> {
         self.keys
             .map(|(x, y)| format!("{}:{}", x.peek(), y.peek()))
-            .map(|key| crate::crypto::blake3::Blake3::hash(&state, Secret::new(key)))
-            .map(|token| hex::encode(&token))
+            .map(|key| crate::crypto::blake3::Blake3::hash(state, Secret::new(key)))
+            .map(hex::encode)
             .map(StrongSecret::new)
     }
 }

--- a/src/core/crypto/custodian.rs
+++ b/src/core/crypto/custodian.rs
@@ -65,7 +65,7 @@ fn extract_credential(
         BASE64_ENGINE
             .decode(credential)
             .change_context(ParsingError::DecodingFailed(
-                "Failed while decoding base64".to_string(),
+                "Failed while base64 decoding the authorization header".to_string(),
             ))?;
     let credential = String::from_utf8(credential).change_context(ParsingError::DecodingFailed(
         "Failed while converting base64 to utf8".to_string(),

--- a/src/core/crypto/decryption.rs
+++ b/src/core/crypto/decryption.rs
@@ -9,14 +9,17 @@ use crate::{
 };
 use opentelemetry::KeyValue;
 
+use super::custodian::Custodian;
+
 pub(super) async fn decryption(
     state: Arc<AppState>,
+    custodian: Custodian,
     req: DecryptionRequest,
 ) -> errors::CustomResult<DecryptionResponse, errors::ApplicationErrorResponse> {
     let identifier = req.identifier.clone();
     let decrypted_data = req
         .data
-        .decrypt(&state, &identifier)
+        .decrypt(&state, &identifier, custodian)
         .await
         .map_err(|err| {
             logger::error!(encryption_error=?err);

--- a/src/core/crypto/encryption.rs
+++ b/src/core/crypto/encryption.rs
@@ -8,14 +8,17 @@ use crate::{
 use opentelemetry::KeyValue;
 use std::sync::Arc;
 
+use super::custodian::Custodian;
+
 pub(super) async fn encryption(
     state: Arc<AppState>,
+    custodian: Custodian,
     req: EncryptDataRequest,
 ) -> errors::CustomResult<EncryptionResponse, errors::ApplicationErrorResponse> {
     let identifier = req.identifier.clone();
     let encrypted_data = req
         .data
-        .encrypt(&state, &identifier)
+        .encrypt(&state, &identifier, custodian)
         .await
         .map_err(|err| {
             logger::error!(encryption_error=?err);

--- a/src/core/datakey.rs
+++ b/src/core/datakey.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::{
     app::AppState,
+    core::custodian::Custodian,
     env::observability as logger,
     errors::{self, ToContainerError},
     metrics,
@@ -22,11 +23,12 @@ use rotate::*;
 #[axum::debug_handler]
 pub async fn create_data_key(
     State(state): State<Arc<AppState>>,
+    custodian: Custodian,
     Json(req): Json<CreateDataKeyRequest>,
 ) -> errors::ApiResponseResult<Json<DataKeyCreateResponse>> {
     let identifier = req.identifier.clone();
 
-    generate_and_create_data_key(state, req)
+    generate_and_create_data_key(state, custodian, req)
         .await
         .map(Json)
         .map_err(|err| {
@@ -48,11 +50,12 @@ pub async fn create_data_key(
 #[axum::debug_handler]
 pub async fn rotate_data_key(
     State(state): State<Arc<AppState>>,
+    custodian: Custodian,
     Json(req): Json<RotateDataKeyRequest>,
 ) -> errors::ApiResponseResult<Json<DataKeyCreateResponse>> {
     let identifier = req.identifier.clone();
 
-    generate_and_rotate_data_key(state, req)
+    generate_and_rotate_data_key(state, custodian, req)
         .await
         .map(Json)
         .map_err(|err| {
@@ -74,9 +77,10 @@ pub async fn rotate_data_key(
 #[axum::debug_handler]
 pub async fn transfer_data_key(
     State(state): State<Arc<AppState>>,
+    custodian: Custodian,
     Json(req): Json<TransferKeyRequest>,
 ) -> errors::ApiResponseResult<Json<DataKeyCreateResponse>> {
-    transfer::transfer_data_key(state, req)
+    transfer::transfer_data_key(state, custodian, req)
         .await
         .map(Json)
         .to_container_error()

--- a/src/core/datakey/create.rs
+++ b/src/core/datakey/create.rs
@@ -25,7 +25,7 @@ pub async fn generate_and_create_data_key(
         identifier: req.identifier.clone(),
         key: aes_key,
         source,
-        token: custodian.into_access_token(state.clone()),
+        token: custodian.into_access_token(state.as_ref()),
     }
     .encrypt(&state)
     .await

--- a/src/core/datakey/create.rs
+++ b/src/core/datakey/create.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     app::AppState,
-    core::crypto::KeyEncrypter,
+    core::{crypto::KeyEncrypter, custodian::Custodian},
     crypto::KeyManagement,
     env::observability as logger,
     errors::{self, SwitchError},
@@ -12,6 +12,7 @@ use crate::{
 
 pub async fn generate_and_create_data_key(
     state: Arc<AppState>,
+    custodian: Custodian,
     req: CreateDataKeyRequest,
 ) -> errors::CustomResult<DataKeyCreateResponse, errors::ApplicationErrorResponse> {
     let db = &state.db_pool;
@@ -24,6 +25,7 @@ pub async fn generate_and_create_data_key(
         identifier: req.identifier.clone(),
         key: aes_key,
         source,
+        token: custodian.into_access_token(state.clone()),
     }
     .encrypt(&state)
     .await

--- a/src/core/datakey/rotate.rs
+++ b/src/core/datakey/rotate.rs
@@ -30,7 +30,7 @@ pub async fn generate_and_rotate_data_key(
         identifier: req.identifier.clone(),
         key: aes_key,
         source,
-        token: custodian.into_access_token(state.clone())
+        token: custodian.into_access_token(state.as_ref()),
     }
     .encrypt(&state)
     .await

--- a/src/core/datakey/rotate.rs
+++ b/src/core/datakey/rotate.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     app::AppState,
-    core::crypto::KeyEncrypter,
+    core::{crypto::KeyEncrypter, custodian::Custodian},
     crypto::KeyManagement,
     env::observability as logger,
     errors::{self, SwitchError},
@@ -12,6 +12,7 @@ use crate::{
 
 pub async fn generate_and_rotate_data_key(
     state: Arc<AppState>,
+    custodian: Custodian,
     req: RotateDataKeyRequest,
 ) -> errors::CustomResult<DataKeyCreateResponse, errors::ApplicationErrorResponse> {
     let db = &state.db_pool;
@@ -29,6 +30,7 @@ pub async fn generate_and_rotate_data_key(
         identifier: req.identifier.clone(),
         key: aes_key,
         source,
+        token: custodian.into_access_token(state.clone())
     }
     .encrypt(&state)
     .await

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -33,7 +33,7 @@ pub async fn transfer_data_key(
         identifier: req.identifier.clone(),
         key: key.into(),
         source: Source::KMS,
-        token: custodian.into_access_token(state.clone())
+        token: custodian.into_access_token(state.as_ref()),
     }
     .encrypt(&state)
     .await

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -5,7 +5,7 @@ use error_stack::ResultExt;
 use crate::{
     app::AppState,
     consts::base64::BASE64_ENGINE,
-    core::crypto::KeyEncrypter,
+    core::{crypto::KeyEncrypter, custodian::Custodian},
     crypto::Source,
     env::observability as logger,
     errors::{self, SwitchError},
@@ -16,6 +16,7 @@ use base64::Engine;
 
 pub async fn transfer_data_key(
     state: Arc<AppState>,
+    custodian: Custodian,
     req: TransferKeyRequest,
 ) -> errors::CustomResult<DataKeyCreateResponse, errors::ApplicationErrorResponse> {
     let db = &state.db_pool;
@@ -32,6 +33,7 @@ pub async fn transfer_data_key(
         identifier: req.identifier.clone(),
         key: key.into(),
         source: Source::KMS,
+        token: custodian.into_access_token(state.clone())
     }
     .encrypt(&state)
     .await

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -7,6 +7,8 @@ use crate::errors::{self, CustomResult};
 
 pub(crate) mod aes256;
 
+pub(crate) mod blake3;
+
 #[cfg(feature = "aws")]
 use crate::services::aws::AwsKmsClient;
 

--- a/src/crypto/blake3.rs
+++ b/src/crypto/blake3.rs
@@ -1,0 +1,16 @@
+use masking::{PeekInterface, Secret};
+
+use crate::app::AppState;
+
+pub struct Blake3;
+
+impl Blake3 {
+    pub fn hash(state: &AppState, key: Secret<String>) -> [u8; 32] {
+        let context = state.conf.secrets.hash_context.peek();
+        let token = state.conf.secrets.access_token.peek();
+        let key = blake3::derive_key(context.as_str(), key.peek().as_bytes());
+        let output = blake3::keyed_hash(&key, token.as_bytes());
+
+        *output.as_bytes()
+    }
+}

--- a/src/errors/app.rs
+++ b/src/errors/app.rs
@@ -18,6 +18,8 @@ mod error_codes {
 pub enum ParsingError {
     #[error("Parsing failed with error {0}")]
     ParsingFailed(String),
+    #[error("Decoding failed with error {0}")]
+    DecodingFailed(String),
 }
 
 pub trait ToContainerError<T> {
@@ -59,6 +61,9 @@ impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, Pars
         self.map_err(|err| {
             let new_err = match err.current_context() {
                 ParsingError::ParsingFailed(s) => {
+                    ApplicationErrorResponse::ParsingFailed(s.to_string())
+                }
+                ParsingError::DecodingFailed(s) => {
                     ApplicationErrorResponse::ParsingFailed(s.to_string())
                 }
             };

--- a/src/errors/crypto.rs
+++ b/src/errors/crypto.rs
@@ -19,6 +19,8 @@ pub enum CryptoError {
     ParseError(String),
     #[error("Invalid value")]
     InvalidValue,
+    #[error("Failed while authenticating the key")]
+    AuthenticationFailed,
 }
 
 impl super::SwitchError<(), CryptoError> for Result<(), ring::error::Unspecified> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,5 +14,7 @@ diesel::table! {
         created_at -> Timestamp,
         #[max_length = 30]
         source -> Varchar,
+        #[max_length = 255]
+        token -> Nullable<Varchar>,
     }
 }

--- a/src/storage/types/dek.rs
+++ b/src/storage/types/dek.rs
@@ -12,6 +12,7 @@ pub struct DataKeyNew {
     pub version: Version,
     pub created_at: PrimitiveDateTime,
     pub source: String,
+    pub token: Option<StrongSecret<String>>,
 }
 
 #[derive(Queryable, Identifiable)]
@@ -24,4 +25,5 @@ pub struct DataKey {
     pub version: Version,
     pub created_at: PrimitiveDateTime,
     pub source: String,
+    pub token: Option<StrongSecret<String>>,
 }

--- a/src/types/core/identifier.rs
+++ b/src/types/core/identifier.rs
@@ -19,6 +19,10 @@ impl Identifier {
             Self::Entity(id) => (String::from("Entity"), id.clone()),
         }
     }
+
+    pub fn is_entity(&self) -> bool {
+        matches!(self, Self::Entity(_))
+    }
 }
 
 impl core::fmt::Display for Identifier {

--- a/src/types/core/key.rs
+++ b/src/types/core/key.rs
@@ -28,6 +28,7 @@ pub struct Key {
     pub key: StrongSecret<[u8; 32]>,
     pub version: Version,
     pub source: Source,
+    pub token: Option<StrongSecret<String>>
 }
 
 impl Key {

--- a/src/types/core/key.rs
+++ b/src/types/core/key.rs
@@ -28,7 +28,7 @@ pub struct Key {
     pub key: StrongSecret<[u8; 32]>,
     pub version: Version,
     pub source: Source,
-    pub token: Option<StrongSecret<String>>
+    pub token: Option<StrongSecret<String>>,
 }
 
 impl Key {

--- a/src/types/method.rs
+++ b/src/types/method.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::AppState,
-    core::{DataDecrypter, DataEncrypter},
+    core::{custodian::Custodian, DataDecrypter, DataEncrypter},
     errors,
     types::Identifier,
 };
@@ -24,10 +24,15 @@ impl DecryptionType {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<EncryptionType, errors::CryptoError> {
         Ok(match self {
-            Self::Single(data) => EncryptionType::Single(data.decrypt(state, identifier).await?),
-            Self::Batch(data) => EncryptionType::Batch(data.decrypt(state, identifier).await?),
+            Self::Single(data) => {
+                EncryptionType::Single(data.decrypt(state, identifier, custodian).await?)
+            }
+            Self::Batch(data) => {
+                EncryptionType::Batch(data.decrypt(state, identifier, custodian).await?)
+            }
         })
     }
 }
@@ -37,10 +42,15 @@ impl EncryptionType {
         self,
         state: &AppState,
         identifier: &Identifier,
+        custodian: Custodian,
     ) -> errors::CustomResult<DecryptionType, errors::CryptoError> {
         Ok(match self {
-            Self::Single(data) => DecryptionType::Single(data.encrypt(state, identifier).await?),
-            Self::Batch(data) => DecryptionType::Batch(data.encrypt(state, identifier).await?),
+            Self::Single(data) => {
+                DecryptionType::Single(data.encrypt(state, identifier, custodian).await?)
+            }
+            Self::Batch(data) => {
+                DecryptionType::Batch(data.encrypt(state, identifier, custodian).await?)
+            }
         })
     }
 }


### PR DESCRIPTION
## Description

Adding custodian support. Adding support for Basic authentication on top of mTLS, to make sure that the keys being accessed belong to the respective party.