### PR TITLE
feat: add support for keymanager service to create TLS connection using sslmode=verify-full 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.10",
+ "rustls 0.23.20",
  "rustls-pemfile 2.1.2",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -521,6 +521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bb8"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,9 +547,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -659,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,10 +710,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -728,6 +750,7 @@ dependencies = [
  "diesel-async",
  "error-stack",
  "futures",
+ "futures-util",
  "hex",
  "hyper 1.3.1",
  "masking",
@@ -740,7 +763,8 @@ dependencies = [
  "rayon",
  "ring",
  "rustc-hash",
- "rustls 0.23.10",
+ "rustls 0.23.20",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
@@ -749,6 +773,8 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tower",
  "tower-http",
  "trace",
@@ -809,6 +835,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,11 +904,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.6"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "ccf1bedf64cdb9643204a36dd15b19a6ce8e7aa7f7b105868e9f1fad5ffa7d12"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "diesel_derives",
  "itoa",
@@ -835,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+checksum = "51a307ac00f7c23f526a04a77761a0519b9f0eb2838ebf5b905a58580095bdcb"
 dependencies = [
  "async-trait",
  "bb8",
@@ -850,11 +934,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -862,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn 2.0.66",
 ]
@@ -887,6 +972,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+dependencies = [
+ "darling",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -953,6 +1052,12 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "flagset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 
 [[package]]
 name = "fnv"
@@ -1299,7 +1404,7 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1318,6 +1423,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1942,7 +2053,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2017,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
@@ -2067,14 +2178,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -2088,7 +2199,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -2112,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -2128,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2190,8 +2313,21 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
- "core-foundation",
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2199,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2345,6 +2481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2500,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -2509,6 +2661,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "tokio"
 version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2738,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls 0.23.20",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.1",
+ "x509-cert",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,8 +2767,18 @@ name = "tokio-rustls"
 version = "0.25.0"
 source = "git+https://github.com/rustls/tokio-rustls?rev=3a153acec6c4d189eb5de501b2155b4484b8651b#3a153acec6c4d189eb5de501b2155b4484b8651b"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.20",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -2653,7 +2851,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -3183,6 +3381,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,3 +3412,17 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.1.0",
 ]
 
 [[package]]
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,6 @@ dependencies = [
  "diesel-async",
  "error-stack",
  "futures",
- "futures-util",
  "hex",
  "hyper 1.3.1",
  "masking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", rev = "3a153ace
 [features]
 mtls = ["dep:rustls", "dep:rustls-pemfile","axum-server/tls-rustls"]
 aws = ["dep:aws-config", "dep:aws-sdk-kms"]
-release = ["aws","mtls"]
+release = ["aws","mtls", "postgres_ssl"]
+postgres_ssl = ["dep:futures-util", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls"]
 
 [dependencies]
 cargo_metadata = "0.18.1"
@@ -21,6 +22,7 @@ aws-sdk-kms = { version = "1.29.0", optional = true}
 axum = { version = "0.7.5", features = ["macros"] }
 axum-server = {git = "https://github.com/dracarys18/axum-server.git",rev ="5430efefd14b43cbbc8e4faa50ff9274b8b8b7aa"}
 base64 = "0.22.1"
+futures-util = { version = "0.3.17", default-features = false, optional = true, features = ["std"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tower-http = {version = "0.5.2", features = ["trace","request-id","util"] }
 ulid = "1.1.2"
@@ -35,6 +37,8 @@ opentelemetry-prometheus = "0.16.0"
 prometheus = "0.13.4"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
+tokio-postgres = { version = "0.7.10", optional = true }
+tokio-postgres-rustls = { version = "0.13.0", optional = true }
 masking = { git = "https://github.com/juspay/hyperswitch", tag = "v1.109.0" }
 async-trait = "0.1.80"
 hex = "0.4.3"
@@ -43,12 +47,13 @@ strum = { version = "0.26", features = ["derive"] }
 futures = "0.3.30"
 time = { version = "0.3.36", features = ["parsing"]}
 diesel = { version = "2.1.3", features = ["postgres", "serde_json", "time"] }
-diesel-async = { version = "0.4.1", features = ["postgres", "bb8"] }
+diesel-async = { version = "0.5.2", features = ["postgres", "bb8"] }
 config = { version = "0.14.0", features = ["toml"] }
 serde_path_to_error = "0.1.16"
 moka = { version = "0.12", default-features = false, features = ["future"]}
+rustls-native-certs = { version="0.8.1", optional = true }
 rustls = { version = "0.23.10", default-features = false,features = ["std"], optional = true}
-rustls-pemfile = {version = "2.1.2", default-features = false, features = ["std"], optional=true }
+rustls-pemfile = { version = "2.1.2", default-features = false, features = ["std"], optional=true }
 rustc-hash = "1.1.0"
 rayon = "1.10.0"
 once_cell = "1.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ mtls = ["dep:rustls", "dep:rustls-pemfile", "axum-server/tls-rustls"]
 aws = []
 release = ["aws", "mtls"]
 vault = []
-postgres_ssl = ["dep:futures-util", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls"]
+postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls"]
 
 [dependencies]
 cargo_metadata = "0.18.1"
@@ -25,7 +25,6 @@ aws-sdk-kms = { version = "1.29.0" }
 axum = { version = "0.7.5", features = ["macros"] }
 axum-server = {git = "https://github.com/dracarys18/axum-server.git",rev ="5430efefd14b43cbbc8e4faa50ff9274b8b8b7aa"}
 base64 = "0.22.1"
-futures-util = { version = "0.3.17", default-features = false, optional = true, features = ["std"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tower-http = {version = "0.5.2", features = ["trace","request-id","util"] }
 ulid = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", rev = "3a153ace
 aes = []
 mtls = ["dep:rustls", "dep:rustls-pemfile", "axum-server/tls-rustls"]
 aws = []
-release = ["aws", "mtls"]
+release = ["aws", "mtls", "postgres_ssl"]
 vault = []
 postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls"]
 

--- a/config/development.toml
+++ b/config/development.toml
@@ -17,6 +17,7 @@ port = 5432
 dbname = "encryption_db"
 pool_size = 5
 min_idle = 2
+enable_ssl = false
 
 [log]
 log_level = "debug"

--- a/config/development.toml
+++ b/config/development.toml
@@ -19,13 +19,6 @@ pool_size = 5
 min_idle = 2
 enable_ssl = false
 
-[cassandra]
-known_nodes = ["localhost:9042"]
-pool_size = 16
-keyspace = "encryption_db"
-timeout = 60
-cache_size = 120
-
 [log]
 log_level = "debug"
 log_format = "console"

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,6 +149,7 @@ pub struct Database {
     pub pool_size: Option<u32>,
     pub min_idle: Option<u32>,
     pub enable_ssl: Option<bool>,
+    pub root_ca: Option<SecretContainer>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,7 @@ pub struct Database {
     pub dbname: masking::Secret<String>,
     pub pool_size: Option<u32>,
     pub min_idle: Option<u32>,
+    pub enable_ssl: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,7 @@ pub struct Config {
     pub metrics_server: Server,
     pub database: Database,
     pub secrets: Secrets,
+    #[serde(default)]
     pub cassandra: Cassandra,
     pub log: LogConfig,
     pub pool_config: PoolConfig,
@@ -143,7 +144,7 @@ pub struct Config {
     pub certs: Certs,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Eq, PartialEq)]
 pub struct Cassandra {
     pub known_nodes: Vec<String>,
     pub keyspace: String,
@@ -192,19 +193,53 @@ pub struct Server {
 
 impl Secrets {
     fn validate(&self) -> CustomResult<(), errors::ParsingError> {
-        if cfg!(feature = "aws") && (self.kms_config == AwsKmsConfig::default()) {
-            Err(error_stack::report!(errors::ParsingError::DecodingFailed(
-                "AWS config is not provided".to_string()
-            )))
-        } else if cfg!(feature = "vault") && (self.vault_config == VaultSettings::default()) {
-            Err(error_stack::report!(errors::ParsingError::DecodingFailed(
-                "Vault config is not provided".to_string()
-            )))
-        } else {
-            Ok(())
+        if cfg!(feature = "aws") {
+            error_stack::ensure!(
+                !self.kms_config.eq(&AwsKmsConfig::default()),
+                errors::ParsingError::DecodingFailed("AWS config is not provided".to_string())
+            )
+        } else if cfg!(feature = "vault") {
+            error_stack::ensure!(
+                !self.vault_config.eq(&VaultSettings::default()),
+                errors::ParsingError::DecodingFailed("Vault config is not provided".to_string())
+            )
+        }
+        Ok(())
+    }
+}
+
+/// # Panics
+///
+/// Panics if the provided pool_size is not a non zero number
+#[allow(clippy::expect_used)]
+impl Default for Cassandra {
+    fn default() -> Self {
+        Self {
+            known_nodes: Vec::new(),
+            keyspace: String::new(),
+            timeout: 0,
+            cache_size: 0,
+            pool_size: NonZeroUsize::new(1).expect("The provided number is non zero"),
         }
     }
 }
+
+impl Cassandra {
+    fn validate(&self) -> CustomResult<(), errors::ParsingError> {
+        if cfg!(feature = "cassandra") {
+            error_stack::ensure!(
+                !self.eq(&Self::default()),
+                errors::ParsingError::DecodingFailed(
+                    "Failed to validate Cassandra configuration, missing configuration found"
+                        .to_string()
+                )
+            )
+        }
+
+        Ok(())
+    }
+}
+
 impl Config {
     pub fn config_path(environment: Environment, explicit_config_path: Option<PathBuf>) -> PathBuf {
         let mut config_path = PathBuf::new();
@@ -247,7 +282,11 @@ impl Config {
     pub fn validate(&self) {
         self.secrets
             .validate()
-            .expect("Failed to valdiate secrets some missing configuration found")
+            .expect("Failed to valdiate secrets some missing configuration found");
+
+        self.cassandra
+            .validate()
+            .expect("Failed to valdiate cassandra some missing configuration found");
     }
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,6 +1,4 @@
 pub(crate) const CONFIG_DIR: &str = "CONFIG_DIR";
-#[cfg(feature = "postgres_ssl")]
-pub(crate) const DB_ROOT_CA_PATH: &str = "DB_ROOT_CA_PATH";
 
 pub mod base64 {
     pub const BASE64_ENGINE: base64::engine::GeneralPurpose =

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,4 +1,6 @@
 pub(crate) const CONFIG_DIR: &str = "CONFIG_DIR";
+#[cfg(feature = "postgres_ssl")]
+pub(crate) const DB_ROOT_CA_PATH: &str = "DB_ROOT_CA_PATH";
 
 pub mod base64 {
     pub(crate) const BASE64_ENGINE: base64::engine::GeneralPurpose =

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,7 +31,7 @@ impl DbState {
 
         let password = database.password.expose(config).await;
 
-        let database_url = format!(
+        let mut database_url = format!(
             "postgres://{}:{}@{}:{}/{}",
             database.user.peek(),
             password.peek(),
@@ -39,6 +39,10 @@ impl DbState {
             database.port,
             database.dbname.peek()
         );
+
+        if database.enable_ssl == Some(true) {
+            database_url.push_str("?sslmode=require");
+        }
 
         let mgr_config = ManagerConfig::default();
         let mgr = AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -96,6 +96,7 @@ impl DbState {
         fut.boxed()
     }
 
+    #[allow(clippy::expect_used)]
     #[cfg(feature = "postgres_ssl")]
     fn root_certs() -> rustls::RootCertStore {
         use crate::{consts::DB_ROOT_CA_PATH, env::observability as logger};
@@ -109,7 +110,6 @@ impl DbState {
                 let cert_data = fs::read(&root_ca_path).expect("Failed to read root cert");
                 let mut reader = BufReader::new(&cert_data[..]);
                 let certs = rustls_pemfile::certs(&mut reader)
-                    .into_iter()
                     .flatten()
                     .collect::<Vec<_>>();
                 for cert in certs {


### PR DESCRIPTION
### PR Description:
- This PR adds feature to enable and disable TLS communication between application and database. 
- With this changes TLS can be enabled in verify-full mode where connection between application and DB will be encrypted and server root ca will also be verified which prevents MITM. For more info [Postgres documentation](https://www.postgresql.org/docs/current/libpq-ssl.html)
- This functionality is under feature flag "postgres_ssl", and only available in the release build

### Steps to enable TLS:
   "database.enable_ssl" in the env should be true and "database.root_ca" should be provided for enabling "verify-full" ssl mode. 

### Steps to disable TLS
   "database.enable_ssl" is an optional field, So setting it as false or not at all having this config in the env will prevent the application to establish connection with DB using TLS.