### PR TITLE
refactor: register health endpoint alongside metrics server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,15 @@ name: CI
 on:
   push:
     branches:
-      - main   
-  pull_request:  
+      - main
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
-        RUSTFLAGS: "-D warnings"
+      RUSTFLAGS: "-D warnings"
 
     steps:
       - name: Checkout code
@@ -38,18 +38,17 @@ jobs:
   formatting:
     name: Check formatting
     runs-on: ubuntu-latest
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt
-      
+
       - name: Check formatting
         shell: bash
-        run: cargo +nightly fmt --all --check     
-    
+        run: cargo +nightly fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           tool: cargo-hack
           checksum: true
 
+      - uses: Swatinem/rust-cache@v2.7.8
+
       - name: Check compilation
         run: cargo hack check --all-features --all-targets
 

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -8,7 +8,8 @@ on:
       - "releases/*"
   pull_request:
   merge_group:
-    types: [checks_requested]
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +33,7 @@ jobs:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_pass
           POSTGRES_DB: encryption_db
-          
+
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/postman-collection-runner.yml
+++ b/.github/workflows/postman-collection-runner.yml
@@ -59,11 +59,11 @@ jobs:
 
       - name: Build and Cache Rust Dependencies
         if: ${{ env.RUN_TESTS == 'true' }}
-        uses: Swatinem/rust-cache@v2.7.0
+        uses: Swatinem/rust-cache@v2.7.8
 
       - name: Install Diesel CLI with Postgres Support
         if: ${{ env.RUN_TESTS == 'true' }}
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: baptiste0928/cargo-install@v3.3.0
         with:
           crate: diesel_cli
           features: postgres

--- a/src/app/tls.rs
+++ b/src/app/tls.rs
@@ -14,10 +14,7 @@ pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
 
     let priv_key =
         rustls_pemfile::private_key(&mut certs.tls_key.expose(config).await.peek().as_ref())?
-            .ok_or(io::Error::new(
-                io::ErrorKind::Other,
-                "Could not parse pem file",
-            ))?;
+            .ok_or(io::Error::other("Could not parse pem file"))?;
 
     let cert = cert.into_iter().map(CertificateDer::from).collect();
 
@@ -25,18 +22,18 @@ pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
 
     for ca in rustls_pemfile::certs(&mut certs.root_ca.expose(config).await.peek().as_ref()) {
         roots
-            .add(ca.map_err(|err| io::Error::new(io::ErrorKind::Other, err))?)
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            .add(ca.map_err(io::Error::other)?)
+            .map_err(io::Error::other)?;
     }
 
     let auth = WebPkiClientVerifier::builder(Arc::new(roots))
         .build()
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     let mut config = ServerConfig::builder()
         .with_client_cert_verifier(auth)
         .with_single_cert(cert, priv_key)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        .map_err(io::Error::other)?;
 
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -95,6 +95,7 @@ async fn spawn_metrics_server(state: Arc<AppState>) {
     );
 
     let app = Router::new()
+        .nest("/health", Health::server(state.clone()))
         .nest("/metrics", Metrics::server(state.clone()))
         .with_state(state);
 


### PR DESCRIPTION
### Description

This PR adds a `/health` endpoint alongside the metrics server, to allow it to be used as a readiness and liveness probe when deploying in Kubernetes environments. Currently, even though there exists a health endpoint, it is behind mTLS, which prevents it from being used as a readiness / liveness probe.

Additionally, this PR addresses some clippy lints stabilized in Rust 1.87. This change affects the `src/app/tls.rs` file alone. 

I've also included some CI improvements in this PR.

I've tested it locally by calling the health endpoint at `http://localhost:6128/health`.