### PR TITLE
refactor(gen_certs): enhancements to the TLS certificate generation script

### DIFF
--- a/scripts/tls/gen_certs.sh
+++ b/scripts/tls/gen_certs.sh
@@ -29,6 +29,10 @@ while [[ $# -gt 0 ]]; do
       shift # past argument
       shift # past value
       ;;
+    --force-server)
+      FORCE_SERVER="true"
+      shift # past argument
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -94,9 +98,13 @@ function gen_rsa_sha256() {
   rm ca_cert.srl server.csr
 }
 
-# Generate server certificate and private key
-gen_rsa_sha256
+# Generate server certificate and private key (only if they don't exist or if forced)
+if [[ ! -f "rsa_sha256_cert.pem" || "$FORCE_SERVER" == "true" ]]; then
+    gen_rsa_sha256
+fi
 
-# Generate client certificate with provided name or default to "client"
+# Ensure CA exists for client cert signing
+gen_ca_if_non_existent
+# Generate client certificate with provided name (or default to "client")
 gen_client_cert_key_pair "${CLIENT_NAME:-client}"
 

--- a/scripts/tls/gen_certs.sh
+++ b/scripts/tls/gen_certs.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#! /usr/bin/env bash
+
+# Additional domains
+DOMAINS=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -13,6 +16,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --service)
       SERVICE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --domain)
+      DOMAINS+=("$2")
       shift # past argument
       shift # past value
       ;;
@@ -32,6 +40,11 @@ else
     CA_SUBJECT="/C=US/ST=CA/O=Cripta CA/CN=Cripta CA"
     SUBJECT="/C=US/ST=CA/O=Cripta/CN=localhost"
 fi
+
+# Append additional domains to ALT
+for domain in "${DOMAINS[@]}"; do
+    ALT="${ALT},DNS:${domain}"
+done
 
 function gen_ca() {
   openssl genrsa -out ca_key.pem 2048


### PR DESCRIPTION
### Description

This PR updates the `scripts/tls/gen_certs.sh` script to support the following features:

1. Ability to generate multi-domain server certificates
2. Proper client certificate generation
3. Ability to generate certificates for multiple clients, without overwriting existing server certificates
4. Validation to check for required parameters in certain situations, and log messages when existing files are being overwritten

The PR can be reviewed one commit at a time, if that helps.

#### 1. Support for multiple domains in server certificate

Added the `--domain` flag, to specify additional domains when generating server certificates. The flag may be specified multiple times to add multiple domains.

**Usage:** `./gen_certs.sh --domain domain1.example.com --domain domain2.example.com`

#### 2. Proper client certificate generation

The previous implementation incorrectly created client certificates by concatenating the server certificate and key ([source](https://github.com/juspay/hyperswitch-encryption-service/blob/35a3d4e920c1c4d0c8904b2673305a3fea0263ec/scripts/tls/gen_certs.sh#L46-L48)). This has been replaced with proper client certificate generation, signed by the same CA. Additionally, a `--client-name` flag has been introduced to allow specifying the client name. If a client name is not specified, the script defaults to `client`.

The client-specific files that are generated are:

- **`client_${name}_cert.pem`**: Client certificate
- **`client_${name}_key.pem`**: Client private key
- **`client_${name}.pem`**: Combined certificate and key file for convenience

#### 3. Generation of multiple client certificates without overwriting server certificates

With the addition of the `--client-name` flag, users may want to generate client certificates for multiple clients that interact with the same server (for example, hyperswitch router and card vault interact with the encryption service). To support such scenarios, the script has been updated to preserve the server certificate files if they already exist, when generating client certificates.

Additionally, a `--force-server` flag has been introduced to allow users to regenerate the server certificate if needed. This flag will overwrite existing server certificate files.

#### 4. Validation and logging improvements

The script now includes validation checks and logging improvements to enhance usability:

- When generating server certificates, the script checks for the presence of `--namespace` and `--service` flags, if `--prod` is specified.
- When the client name is specified, the script checks that the client name contain alphanumeric characters, hyphens and underscores only.
- Clear warnings are displayed when existing server or client certificate files are being overwritten. A message is also displayed when server certificates are skipped if they already exist.

### Testing

1. Generate server and client certificates using this script, using a command like: `scripts/tls/gen_certs.sh --client-name hyperswitch`
2. Configure hyperswitch router to use the generated client certificates, and configure encryption service to use the generated server certificate.
3. Run encryption service using: `cargo run --features mtls`
4. Run hyperswitch router using: `cargo run --bin router --features keymanager_mtls,keymanager_create,encryption_service`
5. I was able to successfully perform operations like merchant account creation and retrieval, which require communication between the router and encryption service. I've also confirmed that the merchant account created had a corresponding entry inserted into the encryption service database.

---

### Generated files reference

This section provides a reference for the files generated by the updated `gen_certs.sh` script, as per the changes in this PR.

#### Certificate Authority (CA) files

- **`ca_cert.pem`**: Root CA certificate used to sign both server and client certificates.
- **`ca_key.pem`**: Private key for the CA (keep secure, used for signing certificates).

#### Server certificate files

- **`rsa_sha256_cert.pem`**: Server certificate containing public key and identity information.
- **`rsa_sha256_key.pem`**: Server private key for TLS encryption/decryption.

The server certificate files are generated with the following properties:
- **Subject:** Contains server hostname (`localhost` for development, `service.namespace.svc.cluster.local` for production).
- **SAN (Subject Alternative Name):** Includes primary hostname plus any additional domains specified via `--domain`.

#### Client certificate files (per client)

- **`client_${name}_cert.pem`**: Client certificate for authentication to the server.
- **`client_${name}_key.pem`**: Client private key for client-side TLS operations.
- **`client_${name}.pem`**: Combined certificate and key file for convenience.

#### Files used in TLS communication

- **For server configuration:** Server needs `rsa_sha256_cert.pem`, `rsa_sha256_key.pem`, and `ca_cert.pem` (for client verification in mTLS).
- **For client configuration:** Client needs `client_${name}.pem` (or separate cert+key files) and `ca_cert.pem` (for server verification).
