### PR TITLE
fix: call `CryptoProvider::install_default()` if either `mtls` or `postgres_ssl` features are enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ mtls = ["dep:rustls", "dep:rustls-pemfile", "axum-server/tls-rustls"]
 aws = []
 release = ["aws", "mtls", "postgres_ssl"]
 vault = []
-postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls"]
+postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls", "rustls/aws_lc_rs"]
 cassandra = []
 
 [dependencies]

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -28,6 +28,11 @@ async fn main() {
 
     logger::info!(?config, "Application starting");
 
+    #[cfg(any(feature = "mtls", feature = "postgres_ssl"))]
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("unable to install default crypto provider");
+
     let state = Arc::new(AppState::from_config(config).await);
 
     let middleware = ServiceBuilder::new()
@@ -58,10 +63,6 @@ async fn main() {
     {
         use axum_server::tls_rustls::RustlsConfig;
         use cripta::app::tls;
-
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .expect("unable to install default crypto provider");
 
         let tls = tls::from_config(&state.conf)
             .await


### PR DESCRIPTION
This PR fixes panics arising from `rustls` when the `postgres_ssl` feature is enabled. I'd fixed a similar panic when the `mtls` feature alone was enabled in #56 (commit https://github.com/juspay/hyperswitch-encryption-service/pull/56/changes/e1b3b2e30a2b4b6666dd6f285a4e0c9544caac1a). This PR moves that code to be called before the state is constructed, when either the `mtls` or `postgres_ssl` feature is enabled.

I've also tested this change by deploying a build with this change on one of our internal environments.

