### PR TITLE
feat: add config to make AWS KMS `key_id` optional during decryption

### DIFF
--- a/src/crypto/kms.rs
+++ b/src/crypto/kms.rs
@@ -76,10 +76,7 @@ impl Crypto for AwsKmsClient {
                 decrypt_request = decrypt_request.key_id(self.key_id());
             }
 
-            let encrypted_output = decrypt_request
-                .send()
-                .await
-                .switch()?;
+            let encrypted_output = decrypt_request.send().await.switch()?;
 
             let output = encrypted_output.plaintext.ok_or(error_stack::report!(
                 errors::CryptoError::EncryptionFailed("KMS")

--- a/src/crypto/kms.rs
+++ b/src/crypto/kms.rs
@@ -65,11 +65,18 @@ impl Crypto for AwsKmsClient {
     fn decrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
         Box::pin(async move {
             let plaintext_blob = Blob::new(input.peek().to_vec());
-            let encrypted_output = self
+            let mut decrypt_request = self
                 .inner_client()
                 .decrypt()
-                .key_id(self.key_id())
-                .ciphertext_blob(plaintext_blob)
+                .ciphertext_blob(plaintext_blob);
+
+            // Only include key_id in decrypt if skip_key_id_on_decrypt is false
+            // When true, KMS determines the key from the ciphertext metadata
+            if !self.skip_key_id_on_decrypt() {
+                decrypt_request = decrypt_request.key_id(self.key_id());
+            }
+
+            let encrypted_output = decrypt_request
                 .send()
                 .await
                 .switch()?;

--- a/src/services/aws/config.rs
+++ b/src/services/aws/config.rs
@@ -10,6 +10,9 @@ pub struct AwsKmsConfig {
 
     /// The AWS region to send KMS requests to.
     pub region: String,
+
+    /// When true, omits key_id from decryption requests, allowing KMS to determine the key from ciphertext metadata.
+    pub skip_key_id_on_decrypt: bool,
 }
 
 /// Client for AWS KMS operations.
@@ -17,6 +20,7 @@ pub struct AwsKmsConfig {
 pub struct AwsKmsClient {
     inner_client: Client,
     key_id: String,
+    skip_key_id_on_decrypt: bool,
 }
 
 impl AwsKmsClient {
@@ -30,6 +34,7 @@ impl AwsKmsClient {
         Self {
             inner_client: Client::new(&sdk_config),
             key_id: config.key_id.clone(),
+            skip_key_id_on_decrypt: config.skip_key_id_on_decrypt,
         }
     }
 
@@ -39,5 +44,9 @@ impl AwsKmsClient {
 
     pub fn key_id(&self) -> &str {
         &self.key_id
+    }
+
+    pub fn skip_key_id_on_decrypt(&self) -> bool {
+        self.skip_key_id_on_decrypt
     }
 }


### PR DESCRIPTION
This PR adds a new config key, when enabled, disables passing key_id on kms decryption: 

```
[secrets.kms_config]
skip_key_id_on_decrypt: true/false
```