### PR TITLE
feat: add logs to encryption service

### DIFF
--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -8,6 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use super::custodian::Custodian;
 use crate::{
     crypto::{Crypto, Source, aes256::GcmAes256},
+    env::observability as logger,
     errors::{self, SwitchError},
     multitenancy::TenantState,
     storage::types::{DataKey, DataKeyNew},
@@ -42,7 +43,11 @@ impl KeyEncrypter<DataKeyNew> for Key {
         let encryption_key = state
             .keymanager_client
             .encrypt_key(self.key.peek().to_vec().into())
-            .await?;
+            .await
+            .map_err(|err| {
+                logger::error!(error=?err, "Failed to encrypt data key with key manager");
+                err
+            })?;
 
         let (data_identifier, key_identifier) = self.identifier.get_identifier();
         Ok(DataKeyNew {
@@ -66,15 +71,23 @@ impl KeyDecrypter<Key> for DataKey {
         let decrypted_key = state
             .keymanager_client
             .decrypt_key(self.encryption_key)
-            .await?;
+            .await
+            .map_err(|err| {
+                logger::error!(error=?err, "Failed to decrypt data key with key manager");
+                err
+            })?;
 
         let decrypted_key = <[u8; 32]>::try_from(decrypted_key.peek().to_vec())
-            .map_err(|_| error_stack::report!(errors::CryptoError::DecryptionFailed("KMS")))?;
+            .map_err(|_| {
+                logger::error!("Decrypted key has invalid length, expected 32 bytes");
+                error_stack::report!(errors::CryptoError::DecryptionFailed("KMS"))
+            })?;
 
         let identifier: errors::CustomResult<Identifier, errors::ParsingError> =
             (self.data_identifier, self.key_identifier).try_into();
 
         let source = Source::from_str(&self.source).switch()?;
+
         Ok(Key {
             identifier: identifier.switch()?,
             version: self.version,
@@ -114,11 +127,18 @@ impl DataEncrypter<MultipleEncryptionDataGroup> for MultipleDecryptionDataGroup 
         custodian: Custodian,
     ) -> errors::CustomResult<MultipleEncryptionDataGroup, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve key for batch encryption");
+                err
+            })?;
 
         let stored_token = decrypted_key.token;
         let provided_token = custodian.into_access_token(state);
 
+        if identifier.is_entity() && !stored_token.eq(&provided_token) {
+            logger::error!(%identifier, "Authentication failed for batch encryption: token mismatch");
+        }
         ensure!(
             !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
@@ -170,6 +190,8 @@ impl DataEncrypter<MultipleEncryptionDataGroup> for MultipleDecryptionDataGroup 
             .flat_map(|group| group.0)
             .collect();
 
+        logger::info!(%identifier, "Batch data encryption completed successfully");
+
         Ok(MultipleEncryptionDataGroup(all_encrypted_groups))
     }
 }
@@ -190,11 +212,18 @@ impl DataDecrypter<MultipleDecryptionDataGroup> for MultipleEncryptionDataGroup 
 
         let decrypted_keys = Key::get_multiple_keys(state, identifier, versions)
             .await
-            .switch()?;
+            .switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve keys for batch decryption");
+                err
+            })?;
 
         if identifier.is_entity() {
             let provided_token = custodian.into_access_token(state);
             let all_tokens_match = decrypted_keys.values().all(|k| k.token.eq(&provided_token));
+            if !all_tokens_match {
+                logger::error!(%identifier, "Authentication failed for batch decryption: token mismatch");
+            }
             ensure!(all_tokens_match, errors::CryptoError::AuthenticationFailed);
         }
         let chunk_size = std::cmp::max(self.0.len() / state.thread_pool.current_num_threads(), 1);
@@ -241,6 +270,8 @@ impl DataDecrypter<MultipleDecryptionDataGroup> for MultipleEncryptionDataGroup 
             .flat_map(|group| group.0)
             .collect();
 
+        logger::info!(%identifier, "Batch data decryption completed successfully");
+
         Ok(MultipleDecryptionDataGroup(all_decrypted_groups))
     }
 }
@@ -254,12 +285,19 @@ impl DataEncrypter<EncryptedDataGroup> for DecryptedDataGroup {
         custodian: Custodian,
     ) -> errors::CustomResult<EncryptedDataGroup, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve key for group encryption");
+                err
+            })?;
         let key = GcmAes256::new(decrypted_key.key)?;
 
         let stored_token = decrypted_key.token;
         let provided_token = custodian.into_access_token(state);
 
+        if identifier.is_entity() && !stored_token.eq(&provided_token) {
+            logger::error!(%identifier, "Authentication failed for group encryption: token mismatch");
+        }
         ensure!(
             !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
@@ -276,7 +314,10 @@ impl DataEncrypter<EncryptedDataGroup> for DecryptedDataGroup {
                     }))
                 })
                 .collect::<errors::CustomResult<FxHashMap<String, EncryptedData>,errors::CryptoError>>()
-        }).map(EncryptedDataGroup)
+        }).map(|group| {
+            logger::info!(%identifier, "Group data encryption completed successfully");
+            EncryptedDataGroup(group)
+        })
     }
 }
 
@@ -291,13 +332,20 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
         let version = FxHashSet::from_iter(self.0.values().map(|d| d.version));
         let decrypted_keys = Key::get_multiple_keys(state, identifier, version)
             .await
-            .switch()?;
+            .switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve keys for group decryption");
+                err
+            })?;
 
-        let mut stored_tokens = decrypted_keys.values().map(|k| &k.token);
         let provided_token = custodian.into_access_token(state);
+        let all_tokens_match = !identifier.is_entity() || decrypted_keys.values().all(|k| k.token.eq(&provided_token));
 
+        if !all_tokens_match {
+            logger::error!(%identifier, "Authentication failed for group decryption: token mismatch");
+        }
         ensure!(
-            !identifier.is_entity() || stored_tokens.all(|t| t.eq(&provided_token)),
+            all_tokens_match,
             errors::CryptoError::AuthenticationFailed
         );
 
@@ -320,7 +368,10 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
             })
             .collect::<errors::CustomResult<FxHashMap<String, DecryptedData>, errors::CryptoError>>(
             )
-        }).map(DecryptedDataGroup)
+        }).map(|group| {
+            logger::info!(%identifier, "Group data decryption completed successfully");
+            DecryptedDataGroup(group)
+        })
     }
 }
 
@@ -333,11 +384,18 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         custodian: Custodian,
     ) -> errors::CustomResult<EncryptedData, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve key for encryption");
+                err
+            })?;
 
         let stored_token = decrypted_key.token;
         let provided_token = custodian.into_access_token(state);
 
+        if identifier.is_entity() && !stored_token.eq(&provided_token) {
+            logger::error!(%identifier, "Authentication failed for encryption: token mismatch");
+        }
         ensure!(
             !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
@@ -346,6 +404,8 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         let key = GcmAes256::new(decrypted_key.key)?;
 
         let encrypted_data = key.encrypt(self.inner())?;
+
+        logger::info!(%identifier, "Data encryption completed successfully");
 
         Ok(EncryptedData {
             version: decrypted_key.version,
@@ -363,11 +423,18 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         custodian: Custodian,
     ) -> errors::CustomResult<DecryptedData, errors::CryptoError> {
         let version = self.version;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()?;
+        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+            .map_err(|err| {
+                logger::error!(error=?err, %identifier, "Failed to retrieve key for decryption");
+                err
+            })?;
 
         let stored_token = decrypted_key.token;
         let provided_token = custodian.into_access_token(state);
 
+        if identifier.is_entity() && !stored_token.eq(&provided_token) {
+            logger::error!(%identifier, "Authentication failed for decryption: token mismatch");
+        }
         ensure!(
             !identifier.is_entity() || (stored_token.eq(&provided_token)),
             errors::CryptoError::AuthenticationFailed
@@ -376,6 +443,8 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         let key = GcmAes256::new(decrypted_key.key)?;
 
         let decrypted_data = key.decrypt(self.inner())?;
+
+        logger::info!(%identifier, "Data decryption completed successfully");
 
         Ok(DecryptedData::from_data(decrypted_data))
     }

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -77,11 +77,10 @@ impl KeyDecrypter<Key> for DataKey {
                 err
             })?;
 
-        let decrypted_key = <[u8; 32]>::try_from(decrypted_key.peek().to_vec())
-            .map_err(|_| {
-                logger::error!("Decrypted key has invalid length, expected 32 bytes");
-                error_stack::report!(errors::CryptoError::DecryptionFailed("KMS"))
-            })?;
+        let decrypted_key = <[u8; 32]>::try_from(decrypted_key.peek().to_vec()).map_err(|_| {
+            logger::error!("Decrypted key has invalid length, expected 32 bytes");
+            error_stack::report!(errors::CryptoError::DecryptionFailed("KMS"))
+        })?;
 
         let identifier: errors::CustomResult<Identifier, errors::ParsingError> =
             (self.data_identifier, self.key_identifier).try_into();
@@ -339,15 +338,13 @@ impl DataDecrypter<DecryptedDataGroup> for EncryptedDataGroup {
             })?;
 
         let provided_token = custodian.into_access_token(state);
-        let all_tokens_match = !identifier.is_entity() || decrypted_keys.values().all(|k| k.token.eq(&provided_token));
+        let all_tokens_match =
+            !identifier.is_entity() || decrypted_keys.values().all(|k| k.token.eq(&provided_token));
 
         if !all_tokens_match {
             logger::error!(%identifier, "Authentication failed for group decryption: token mismatch");
         }
-        ensure!(
-            all_tokens_match,
-            errors::CryptoError::AuthenticationFailed
-        );
+        ensure!(all_tokens_match, errors::CryptoError::AuthenticationFailed);
 
         state.thread_pool.install(|| {
             self
@@ -384,7 +381,9 @@ impl DataEncrypter<EncryptedData> for DecryptedData {
         custodian: Custodian,
     ) -> errors::CustomResult<EncryptedData, errors::CryptoError> {
         let version = Version::get_latest(identifier, state).await;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+        let decrypted_key = Key::get_key(state, identifier, version)
+            .await
+            .switch()
             .map_err(|err| {
                 logger::error!(error=?err, %identifier, "Failed to retrieve key for encryption");
                 err
@@ -423,7 +422,9 @@ impl DataDecrypter<DecryptedData> for EncryptedData {
         custodian: Custodian,
     ) -> errors::CustomResult<DecryptedData, errors::CryptoError> {
         let version = self.version;
-        let decrypted_key = Key::get_key(state, identifier, version).await.switch()
+        let decrypted_key = Key::get_key(state, identifier, version)
+            .await
+            .switch()
             .map_err(|err| {
                 logger::error!(error=?err, %identifier, "Failed to retrieve key for decryption");
                 err

--- a/src/core/crypto/decryption.rs
+++ b/src/core/crypto/decryption.rs
@@ -20,7 +20,7 @@ pub(super) async fn decryption(
         .decrypt(&state, &identifier, custodian)
         .await
         .map_err(|err| {
-            logger::error!(encryption_error=?err);
+            logger::error!(decryption_error=?err);
 
             let (data_identifier, key_identifier) = identifier.get_identifier();
             metrics::DECRYPTION_FAILURE.add(

--- a/src/core/datakey.rs
+++ b/src/core/datakey.rs
@@ -78,5 +78,9 @@ pub async fn transfer_data_key(
     transfer::transfer_data_key(state, custodian, req)
         .await
         .map(Json)
+        .map_err(|err| {
+            logger::error!(key_transfer_failure=?err);
+            err
+        })
         .to_container_error()
 }

--- a/src/core/datakey/create.rs
+++ b/src/core/datakey/create.rs
@@ -15,7 +15,11 @@ pub async fn generate_and_create_data_key(
     let db = state.get_db_pool();
     let version = Version::get_latest(&req.identifier, &state).await;
 
-    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()
+    let (source, aes_key) = state
+        .keymanager_client
+        .generate_key()
+        .await
+        .switch()
         .map_err(|err| {
             logger::error!(error=?err, "Failed to generate data key");
             err
@@ -36,7 +40,10 @@ pub async fn generate_and_create_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()
+    let data_key = db
+        .get_or_insert_data_key(key)
+        .await
+        .switch()
         .map_err(|err| {
             logger::error!(error=?err, "Failed to store data key in database");
             err

--- a/src/core/datakey/create.rs
+++ b/src/core/datakey/create.rs
@@ -15,7 +15,11 @@ pub async fn generate_and_create_data_key(
     let db = state.get_db_pool();
     let version = Version::get_latest(&req.identifier, &state).await;
 
-    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()?;
+    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to generate data key");
+            err
+        })?;
 
     let key = Key {
         version,
@@ -32,7 +36,14 @@ pub async fn generate_and_create_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to store data key in database");
+            err
+        })?;
+
+    logger::info!(%req.identifier, version=%data_key.version, "Data key created successfully");
+
     Ok(DataKeyCreateResponse {
         key_version: data_key.version,
         identifier: req.identifier,

--- a/src/core/datakey/rotate.rs
+++ b/src/core/datakey/rotate.rs
@@ -16,11 +16,19 @@ pub async fn generate_and_rotate_data_key(
     let version = db
         .get_latest_version(&req.identifier)
         .await
-        .switch()?
+        .switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to get latest key version during rotation");
+            err
+        })?
         .increment()
         .switch()?;
 
-    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()?;
+    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to generate data key during rotation");
+            err
+        })?;
 
     let key = Key {
         version,
@@ -37,7 +45,14 @@ pub async fn generate_and_rotate_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to store rotated data key in database");
+            err
+        })?;
+
+    logger::info!(%req.identifier, version=%data_key.version, "Data key rotated successfully");
+
     Ok(DataKeyCreateResponse {
         key_version: data_key.version,
         identifier: req.identifier,

--- a/src/core/datakey/rotate.rs
+++ b/src/core/datakey/rotate.rs
@@ -24,7 +24,11 @@ pub async fn generate_and_rotate_data_key(
         .increment()
         .switch()?;
 
-    let (source, aes_key) = state.keymanager_client.generate_key().await.switch()
+    let (source, aes_key) = state
+        .keymanager_client
+        .generate_key()
+        .await
+        .switch()
         .map_err(|err| {
             logger::error!(error=?err, "Failed to generate data key during rotation");
             err
@@ -45,7 +49,10 @@ pub async fn generate_and_rotate_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()
+    let data_key = db
+        .get_or_insert_data_key(key)
+        .await
+        .switch()
         .map_err(|err| {
             logger::error!(error=?err, "Failed to store rotated data key in database");
             err

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -42,7 +42,13 @@ pub async fn transfer_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()?;
+    let data_key = db.get_or_insert_data_key(key).await.switch()
+        .map_err(|err| {
+            logger::error!(error=?err, "Failed to store transferred data key in database");
+            err
+        })?;
+
+    logger::info!(%req.identifier, version=%data_key.version, "Data key transferred successfully");
 
     Ok(DataKeyCreateResponse {
         identifier: req.identifier,

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -42,7 +42,10 @@ pub async fn transfer_data_key(
         err
     })?;
 
-    let data_key = db.get_or_insert_data_key(key).await.switch()
+    let data_key = db
+        .get_or_insert_data_key(key)
+        .await
+        .switch()
         .map_err(|err| {
             logger::error!(error=?err, "Failed to store transferred data key in database");
             err

--- a/src/crypto/kms.rs
+++ b/src/crypto/kms.rs
@@ -6,6 +6,7 @@ use masking::{PeekInterface, StrongSecret};
 
 use crate::{
     crypto::{Crypto, Source},
+    env::observability as logger,
     errors::{self, CustomResult, SwitchError},
     services::aws::AwsKmsClient,
 };
@@ -33,10 +34,18 @@ impl Crypto for AwsKmsClient {
 
         let plaintext_blob = <[u8; 32]>::try_from(
             resp.plaintext
-                .ok_or(error_stack::report!(errors::CryptoError::KeyGeneration))?
+                .ok_or_else(|| {
+                    logger::error!("KMS GenerateDataKey returned no plaintext");
+                    error_stack::report!(errors::CryptoError::KeyGeneration)
+                })?
                 .into_inner(),
         )
-        .map_err(|_| error_stack::report!(errors::CryptoError::KeyGeneration))?;
+        .map_err(|_| {
+            logger::error!("KMS generated key has invalid length, expected 32 bytes");
+            error_stack::report!(errors::CryptoError::KeyGeneration)
+        })?;
+
+        logger::info!("KMS data key generated successfully");
 
         Ok((Source::KMS, plaintext_blob.into()))
     }
@@ -55,9 +64,12 @@ impl Crypto for AwsKmsClient {
 
             let output = encrypted_output
                 .ciphertext_blob
-                .ok_or(error_stack::report!(errors::CryptoError::EncryptionFailed(
-                    "KMS"
-                )))?;
+                .ok_or_else(|| {
+                    logger::error!("KMS encrypt returned no ciphertext blob");
+                    error_stack::report!(errors::CryptoError::EncryptionFailed("KMS"))
+                })?;
+
+            logger::info!("KMS encryption completed successfully");
 
             Ok(output.into_inner().into())
         })
@@ -78,9 +90,12 @@ impl Crypto for AwsKmsClient {
 
             let encrypted_output = decrypt_request.send().await.switch()?;
 
-            let output = encrypted_output.plaintext.ok_or(error_stack::report!(
-                errors::CryptoError::EncryptionFailed("KMS")
-            ))?;
+            let output = encrypted_output.plaintext.ok_or_else(|| {
+                logger::error!("KMS decrypt returned no plaintext");
+                error_stack::report!(errors::CryptoError::DecryptionFailed("KMS"))
+            })?;
+
+            logger::info!("KMS decryption completed successfully");
 
             Ok(output.into_inner().into())
         })

--- a/src/crypto/kms.rs
+++ b/src/crypto/kms.rs
@@ -62,12 +62,10 @@ impl Crypto for AwsKmsClient {
                 .await
                 .switch()?;
 
-            let output = encrypted_output
-                .ciphertext_blob
-                .ok_or_else(|| {
-                    logger::error!("KMS encrypt returned no ciphertext blob");
-                    error_stack::report!(errors::CryptoError::EncryptionFailed("KMS"))
-                })?;
+            let output = encrypted_output.ciphertext_blob.ok_or_else(|| {
+                logger::error!("KMS encrypt returned no ciphertext blob");
+                error_stack::report!(errors::CryptoError::EncryptionFailed("KMS"))
+            })?;
 
             logger::info!("KMS encryption completed successfully");
 

--- a/src/crypto/vault.rs
+++ b/src/crypto/vault.rs
@@ -72,22 +72,30 @@ impl Crypto for Vault {
             None,
         )
         .await
-        .map_err(|err| report!(err).change_context(errors::CryptoError::KeyGeneration))?;
+        .map_err(|err| {
+            logger::error!(error=?err, "Vault key generation failed");
+            report!(err).change_context(errors::CryptoError::KeyGeneration)
+        })?;
         let key = BASE64_ENGINE
             .decode(response.random_bytes)
-            .map_err(|err| report!(err).change_context(CryptoError::KeyGeneration))?;
+            .map_err(|err| {
+                logger::error!(error=?err, "Failed to decode Vault random bytes");
+                report!(err).change_context(CryptoError::KeyGeneration)
+            })?;
         let buffer: [u8; 32] = key.try_into().map_err(|err: Vec<u8>| {
             let err_bytes = format!("{err:?}");
             logger::debug!(err_bytes);
             report!(CryptoError::KeyGeneration)
         })?;
+        logger::info!("Vault key generated successfully");
+
         Ok((Source::HashicorpVault, buffer.into()))
     }
 
     fn encrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
         let b64_text = BASE64_ENGINE.encode(input.peek());
         Box::pin(async move {
-            Ok(transit::data::encrypt(
+            let result = transit::data::encrypt(
                 &self.inner_client,
                 &self.settings.mount_point,
                 &self.settings.encryption_key,
@@ -96,18 +104,24 @@ impl Crypto for Vault {
             )
             .await
             .map_err(|err| {
+                logger::error!(error=?err, "Vault encryption failed");
                 report!(err).change_context(CryptoError::EncryptionFailed("HashiCorp Vault"))
             })?
             .ciphertext
             .as_bytes()
             .to_vec()
-            .into())
+            .into();
+
+            logger::info!("Vault encryption completed successfully");
+
+            Ok(result)
         })
     }
 
     fn decrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
         Box::pin(async move {
             let cypher_text = String::from_utf8(input.peek().to_vec()).map_err(|err| {
+                logger::error!(error=?err, "Failed to convert Vault ciphertext to UTF-8");
                 report!(err).change_context(CryptoError::DecryptionFailed("Vault"))
             })?;
             let b64_encoded_str = transit::data::decrypt(
@@ -119,15 +133,21 @@ impl Crypto for Vault {
             )
             .await
             .map_err(|err| {
+                logger::error!(error=?err, "Vault decryption failed");
                 report!(err).change_context(CryptoError::DecryptionFailed("HashiCorp Vault"))
             })?
             .plaintext;
-            Ok(BASE64_ENGINE
+            let result = BASE64_ENGINE
                 .decode(b64_encoded_str)
                 .map_err(|err| {
+                    logger::error!(error=?err, "Failed to decode Vault decrypted base64 data");
                     report!(err).change_context(CryptoError::DecryptionFailed("HashiCorp Vault"))
                 })?
-                .into())
+                .into();
+
+            logger::info!("Vault decryption completed successfully");
+
+            Ok(result)
         })
     }
 }

--- a/src/crypto/vault.rs
+++ b/src/crypto/vault.rs
@@ -76,12 +76,10 @@ impl Crypto for Vault {
             logger::error!(error=?err, "Vault key generation failed");
             report!(err).change_context(errors::CryptoError::KeyGeneration)
         })?;
-        let key = BASE64_ENGINE
-            .decode(response.random_bytes)
-            .map_err(|err| {
-                logger::error!(error=?err, "Failed to decode Vault random bytes");
-                report!(err).change_context(CryptoError::KeyGeneration)
-            })?;
+        let key = BASE64_ENGINE.decode(response.random_bytes).map_err(|err| {
+            logger::error!(error=?err, "Failed to decode Vault random bytes");
+            report!(err).change_context(CryptoError::KeyGeneration)
+        })?;
         let buffer: [u8; 32] = key.try_into().map_err(|err: Vec<u8>| {
             let err_bytes = format!("{err:?}");
             logger::debug!(err_bytes);

--- a/src/errors/app.rs
+++ b/src/errors/app.rs
@@ -2,6 +2,7 @@ use axum::response::{IntoResponse, Response};
 use hyper::StatusCode;
 
 use super::SwitchError;
+use crate::env::observability as logger;
 
 pub type ApiResponseResult<T> = Result<T, ApiErrorContainer>;
 
@@ -68,6 +69,7 @@ pub enum ApplicationErrorResponse {
 impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, ParsingError> {
     fn switch(self) -> super::CustomResult<T, ApplicationErrorResponse> {
         self.map_err(|err| {
+            logger::error!(parsing_error=?err, "Error during request parsing");
             let new_err = match err.current_context() {
                 ParsingError::ParsingFailed(s) => {
                     ApplicationErrorResponse::ParsingFailed(s.to_string())
@@ -86,6 +88,7 @@ impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, Pars
 impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, super::CryptoError> {
     fn switch(self) -> super::CustomResult<T, ApplicationErrorResponse> {
         self.map_err(|err| {
+            logger::error!(crypto_error=?err, "Crypto operation failed");
             let new_err = match err.current_context() {
                 super::CryptoError::EncryptionFailed(_) => {
                     ApplicationErrorResponse::InternalServerError("Encryption failed")
@@ -113,6 +116,7 @@ impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, supe
 impl<T> SwitchError<T, ApplicationErrorResponse> for super::CustomResult<T, super::DatabaseError> {
     fn switch(self) -> super::CustomResult<T, ApplicationErrorResponse> {
         self.map_err(|err| {
+            logger::error!(database_error=?err, "Database operation failed");
             let new_err = match err.current_context() {
                 super::DatabaseError::NotFound => ApplicationErrorResponse::NotFound("Database"),
                 super::DatabaseError::ConnectionError(_)

--- a/src/errors/db.rs
+++ b/src/errors/db.rs
@@ -35,7 +35,7 @@ impl<T> super::SwitchError<T, DatabaseError> for super::CustomResult<T, Connecti
 impl<T> super::SwitchError<T, DatabaseError> for Result<T, diesel::result::Error> {
     fn switch(self) -> super::CustomResult<T, DatabaseError> {
         self.map_err(|diesel_err| {
-            let database_error = match diesel_err {
+            let database_error = match &diesel_err {
                 diesel_error::NotFound => DatabaseError::NotFound,
                 diesel_error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
                     DatabaseError::UniqueViolation
@@ -43,7 +43,10 @@ impl<T> super::SwitchError<T, DatabaseError> for Result<T, diesel::result::Error
                 diesel_error::DatabaseError(DatabaseErrorKind::NotNullViolation, _) => {
                     DatabaseError::NotNullViolation
                 }
-                _ => DatabaseError::Others,
+                err => {
+                    logger::error!(diesel_err=?err);
+                    DatabaseError::Others
+                }
             };
 
             report!(diesel_err).change_context(database_error)

--- a/src/multitenancy.rs
+++ b/src/multitenancy.rs
@@ -55,9 +55,7 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for TenantState {
             .get(TENANT_HEADER)
             .ok_or_else(|| {
                 logger::error!("Tenant header is missing from request");
-                error_stack::Report::new(
-                    errors::ApplicationErrorResponse::TenantIdNotFound,
-                )
+                error_stack::Report::new(errors::ApplicationErrorResponse::TenantIdNotFound)
             })
             .and_then(|header| extract_tenant(state, header).switch())
             .to_container_error()
@@ -79,8 +77,6 @@ fn extract_tenant(
         .cloned()
         .ok_or_else(|| {
             logger::error!(tenant_id=%tenant, "Tenant ID not found in configured tenants");
-            error_stack::Report::new(
-                errors::ParsingError::TenantIdNotFound,
-            )
+            error_stack::Report::new(errors::ParsingError::TenantIdNotFound)
         })
 }

--- a/src/multitenancy.rs
+++ b/src/multitenancy.rs
@@ -7,6 +7,7 @@ use rustc_hash::FxHashMap;
 use crate::{
     app::{AppState, SessionState, StorageState},
     consts::TENANT_HEADER,
+    env::observability as logger,
     errors::{self, ApiErrorContainer, SwitchError, ToContainerError},
 };
 
@@ -52,9 +53,12 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for TenantState {
         parts
             .headers
             .get(TENANT_HEADER)
-            .ok_or(error_stack::Report::new(
-                errors::ApplicationErrorResponse::TenantIdNotFound,
-            ))
+            .ok_or_else(|| {
+                logger::error!("Tenant header is missing from request");
+                error_stack::Report::new(
+                    errors::ApplicationErrorResponse::TenantIdNotFound,
+                )
+            })
             .and_then(|header| extract_tenant(state, header).switch())
             .to_container_error()
     }
@@ -71,9 +75,12 @@ fn extract_tenant(
 
     state
         .tenant_states
-        .get(&TenantId::new(tenant))
+        .get(&TenantId::new(tenant.clone()))
         .cloned()
-        .ok_or(error_stack::Report::new(
-            errors::ParsingError::TenantIdNotFound,
-        ))
+        .ok_or_else(|| {
+            logger::error!(tenant_id=%tenant, "Tenant ID not found in configured tenants");
+            error_stack::Report::new(
+                errors::ParsingError::TenantIdNotFound,
+            )
+        })
 }

--- a/src/storage/adapter/cassandra/dek.rs
+++ b/src/storage/adapter/cassandra/dek.rs
@@ -41,6 +41,10 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
                     .consistency(Consistency::EachQuorum)
                     .execute(connection)
                     .await
+                    .map_err(|err| {
+                        logger::error!(cassandra_insert_err=?err);
+                        err
+                    })
                     .switch()?;
                 Ok(key)
             }
@@ -54,11 +58,15 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
         let (data_id, key_id) = identifier.get_identifier();
         let connection = self.get_conn().await.switch()?;
 
-        let data_key = DataKey::find_first_by_key_identifier_and_data_identifier(key_id, data_id)
+        let data_key = DataKey::find_first_by_key_identifier_and_data_identifier(key_id.clone(), data_id.clone())
             .consistency(scylla::statement::Consistency::LocalQuorum)
             .execute(connection)
             .await
-            .switch()?;
+            .switch()
+            .map_err(|err| {
+                logger::error!(error=?err, data_identifier=%data_id, key_identifier=%key_id, "Failed to get latest key version from cassandra");
+                err
+            })?;
 
         Ok(data_key.version)
     }
@@ -72,11 +80,15 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
         let connection = self.get_conn().await.switch()?;
 
         let data_key =
-            DataKey::find_by_key_identifier_and_data_identifier_and_version(key_id, data_id, v)
+            DataKey::find_by_key_identifier_and_data_identifier_and_version(key_id.clone(), data_id.clone(), v)
                 .consistency(scylla::statement::Consistency::LocalQuorum)
                 .execute(connection)
                 .await
-                .switch()?;
+                .switch()
+                .map_err(|err| {
+                    logger::error!(error=?err, %v, data_identifier=%data_id, key_identifier=%key_id, "Failed to get data key from cassandra");
+                    err
+                })?;
 
         Ok(data_key)
     }

--- a/src/storage/adapter/postgres/dek.rs
+++ b/src/storage/adapter/postgres/dek.rs
@@ -33,9 +33,7 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
             Ok(result) => Ok(result),
             Err(err) => match err.current_context() {
                 errors::DatabaseError::UniqueViolation => {
-                    logger::warn!(
-                        "Data key already exists, fetching existing key"
-                    );
+                    logger::warn!("Data key already exists, fetching existing key");
                     self.get_key(
                         v,
                         &identifier
@@ -62,7 +60,11 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
         let query = DataKey::table()
             .select(version)
             .order_by(version.desc())
-            .filter(data_identifier.eq(d_id.clone()).and(key_identifier.eq(k_id.clone())));
+            .filter(
+                data_identifier
+                    .eq(d_id.clone())
+                    .and(key_identifier.eq(k_id.clone())),
+            );
 
         query.get_result(&mut connection).await.switch().map_err(|err| {
             logger::error!(error=?err, data_identifier=%d_id, key_identifier=%k_id, "Failed to get latest key version from database");
@@ -80,9 +82,11 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
         let (d_id, k_id) = identifier.get_identifier();
 
         let query = DataKey::table().filter(
-            version
-                .eq(v)
-                .and(data_identifier.eq(d_id.clone()).and(key_identifier.eq(k_id.clone()))),
+            version.eq(v).and(
+                data_identifier
+                    .eq(d_id.clone())
+                    .and(key_identifier.eq(k_id.clone())),
+            ),
         );
         query.get_result(&mut connection).await.switch().map_err(|err| {
             logger::error!(error=?err, %v, data_identifier=%d_id, key_identifier=%k_id, "Failed to get data key from database");

--- a/src/storage/adapter/postgres/dek.rs
+++ b/src/storage/adapter/postgres/dek.rs
@@ -4,6 +4,7 @@ use error_stack::ResultExt;
 
 use super::DbState;
 use crate::{
+    env::observability as logger,
     errors::{self, CustomResult, SwitchError},
     schema::data_key_store::*,
     storage::{
@@ -32,6 +33,9 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
             Ok(result) => Ok(result),
             Err(err) => match err.current_context() {
                 errors::DatabaseError::UniqueViolation => {
+                    logger::warn!(
+                        "Data key already exists, fetching existing key"
+                    );
                     self.get_key(
                         v,
                         &identifier
@@ -40,7 +44,10 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
                     )
                     .await
                 }
-                _ => Err(err),
+                _ => {
+                    logger::error!(error=?err, "Failed to insert data key into database");
+                    Err(err)
+                }
             },
         }
     }
@@ -55,9 +62,12 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
         let query = DataKey::table()
             .select(version)
             .order_by(version.desc())
-            .filter(data_identifier.eq(d_id).and(key_identifier.eq(k_id)));
+            .filter(data_identifier.eq(d_id.clone()).and(key_identifier.eq(k_id.clone())));
 
-        query.get_result(&mut connection).await.switch()
+        query.get_result(&mut connection).await.switch().map_err(|err| {
+            logger::error!(error=?err, data_identifier=%d_id, key_identifier=%k_id, "Failed to get latest key version from database");
+            err
+        })
     }
 
     async fn get_key(
@@ -72,8 +82,11 @@ impl DataKeyStorageInterface for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
         let query = DataKey::table().filter(
             version
                 .eq(v)
-                .and(data_identifier.eq(d_id).and(key_identifier.eq(k_id))),
+                .and(data_identifier.eq(d_id.clone()).and(key_identifier.eq(k_id.clone()))),
         );
-        query.get_result(&mut connection).await.switch()
+        query.get_result(&mut connection).await.switch().map_err(|err| {
+            logger::error!(error=?err, %v, data_identifier=%d_id, key_identifier=%k_id, "Failed to get data key from database");
+            err
+        })
     }
 }

--- a/src/types/core/key.rs
+++ b/src/types/core/key.rs
@@ -177,7 +177,10 @@ impl Version {
         )
         .await;
 
-        v.unwrap_or_default()
+        v.unwrap_or_else(|err| {
+            logger::warn!(error=?err, %identifier, "Failed to get latest version, using default");
+            Self::default()
+        })
     }
 
     pub fn increment(self) -> errors::CustomResult<Self, errors::ParsingError> {


### PR DESCRIPTION
This pull request introduces comprehensive logging and improved error handling throughout the cryptography and data key management modules. The changes add detailed error logs for failed operations, info logs for successful ones, and ensure that all errors are captured and reported with relevant context. This will make debugging and monitoring much easier, especially in production environments.

Key improvements include:

**Error Logging and Handling Enhancements:**

* Added error logs to all places where key generation, encryption, decryption, and database operations can fail in `crux.rs`, `datakey.rs`, and `kms.rs`, providing detailed context for each failure. [[1]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L45-R50) [[2]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L69-R90) [[3]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L117-R141) [[4]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L193-R226) [[5]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L257-R300) [[6]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L294-R348) [[7]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L336-R398) [[8]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L366-R437) [[9]](diffhunk://#diff-97655b731bd8cb9f17b535bf3fd5d25ae26fdb613141be6f5ed471df024aa1abL18-R22) [[10]](diffhunk://#diff-97655b731bd8cb9f17b535bf3fd5d25ae26fdb613141be6f5ed471df024aa1abL35-R46) [[11]](diffhunk://#diff-7c033d504ca18fb32cb770912bcdef33bfef23008314719a9a97cd1e07d81513L19-R31) [[12]](diffhunk://#diff-7c033d504ca18fb32cb770912bcdef33bfef23008314719a9a97cd1e07d81513L40-R55) [[13]](diffhunk://#diff-072b53c99a7234cffb2e86cf3c1fe3fd01556b60d03b6dce0d55d7dab2da4d21L45-R51) [[14]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L36-R48) [[15]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L58-R72) [[16]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L81-R98) [[17]](diffhunk://#diff-20013c04a10760a1a7c271194a07c4eed0de241144c5ce9cc8684bd9567dba6bR81-R84) [[18]](diffhunk://#diff-a664f5e029c44e7f4fc81d40241614280560b3b305f6c3d8ea32c5bba41eb938L23-R23)

**Success Logging:**

* Added info logs for successful key generation, encryption, decryption, and database operations, including key creation, rotation, and transfer, as well as batch and group operations. [[1]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03R193-R194) [[2]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03R273-R274) [[3]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L279-R320) [[4]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L323-R374) [[5]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03R408-R409) [[6]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03R447-R448) [[7]](diffhunk://#diff-97655b731bd8cb9f17b535bf3fd5d25ae26fdb613141be6f5ed471df024aa1abL35-R46) [[8]](diffhunk://#diff-7c033d504ca18fb32cb770912bcdef33bfef23008314719a9a97cd1e07d81513L40-R55) [[9]](diffhunk://#diff-072b53c99a7234cffb2e86cf3c1fe3fd01556b60d03b6dce0d55d7dab2da4d21L45-R51) [[10]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L36-R48) [[11]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L58-R72) [[12]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3L81-R98)

**Authentication Failure Logging:**

* Added explicit error logs for authentication failures due to token mismatches in all relevant encryption and decryption flows. [[1]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L117-R141) [[2]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L193-R226) [[3]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L257-R300) [[4]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L294-R348) [[5]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L336-R398) [[6]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03L366-R437)

**Consistency and Observability:**

* Standardized the use of the `logger` module (`env::observability`) across all affected files for consistent logging. [[1]](diffhunk://#diff-e34fb7725e7d55a385fb8f721e58cad893b5b882a6ebcde9b7bbdad53f910d03R11) [[2]](diffhunk://#diff-296846280d5f564592b96e816d92cd04676201d6c108a8c8c4e052525dacabc3R9)

**Minor Corrections:**

* Fixed a typo in a log key from `encryption_error` to `decryption_error` in `decryption.rs`.

These changes will provide much better insight into the system's behavior and make troubleshooting significantly easier.