### PR TITLE
chore: add AwsKmsDecryptionConfig, AwsKmsEncryptionConfig for cross region encryption and decryption

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -35,3 +35,12 @@ log_format = "console"
 master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
 access_token = "secret123"
 hash_context = "keymanager:hyperswitch"
+
+# [secrets.kms_encryption_config]
+# key_id = "arn:aws:kms:ap-south-1:123456789:key/encrypt-key-id"
+# region = "ap-south-1"
+#
+# [secrets.kms_decryption_config]
+# key_id = "arn:aws:kms:us-east-1:123456789:key/decrypt-key-id"
+# region = "us-east-1"
+# skip_key_id_on_decrypt = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     env::observability::LogConfig,
     errors::{self, CustomResult},
-    services::aws::{AwsKmsClient, AwsKmsConfig},
+    services::aws::{AwsKmsClient, AwsKmsDecryptionConfig, AwsKmsEncryptionConfig},
 };
 
 pub mod vars {
@@ -61,7 +61,7 @@ impl SecretContainer {
         if cfg!(feature = "aws") {
             use base64::Engine;
 
-            let kms = AwsKmsClient::new(&config.secrets.kms_config).await;
+            let kms = AwsKmsClient::new_for_decryption(&config.secrets.kms_decryption_config).await;
             let data = crate::consts::base64::BASE64_ENGINE
                 .decode(self.0.peek())
                 .expect("Unable to base64 decode secret");
@@ -189,7 +189,9 @@ pub struct Secrets {
     #[serde(default)]
     pub master_key: GcmAes256,
     #[serde(default)]
-    pub kms_config: AwsKmsConfig,
+    pub kms_encryption_config: AwsKmsEncryptionConfig,
+    #[serde(default)]
+    pub kms_decryption_config: AwsKmsDecryptionConfig,
     #[serde(default)]
     pub vault_config: VaultSettings,
     pub access_token: SecretContainer,
@@ -206,8 +208,16 @@ impl Secrets {
     fn validate(&self) -> CustomResult<(), errors::ParsingError> {
         if cfg!(feature = "aws") {
             error_stack::ensure!(
-                !self.kms_config.eq(&AwsKmsConfig::default()),
-                errors::ParsingError::DecodingFailed("AWS config is not provided".to_string())
+                !self.kms_encryption_config.eq(&AwsKmsEncryptionConfig::default()),
+                errors::ParsingError::DecodingFailed(
+                    "AWS encryption config is not provided".to_string()
+                )
+            );
+            error_stack::ensure!(
+                !self.kms_decryption_config.eq(&AwsKmsDecryptionConfig::default()),
+                errors::ParsingError::DecodingFailed(
+                    "AWS decryption config is not provided".to_string()
+                )
             )
         } else if cfg!(feature = "vault") {
             error_stack::ensure!(
@@ -318,14 +328,22 @@ impl Config {
 impl Secrets {
     pub async fn create_keymanager_client(self) -> KeyManagerClient {
         if cfg!(feature = "aws") {
-            let client = AwsKmsClient::new(&self.kms_config).await;
-            KeyManagerClient::new(Arc::new(client))
+            let encryption_client =
+                AwsKmsClient::new_for_encryption(&self.kms_encryption_config).await;
+            let decryption_client =
+                AwsKmsClient::new_for_decryption(&self.kms_decryption_config).await;
+            KeyManagerClient::new(
+                Arc::new(encryption_client),
+                Arc::new(decryption_client),
+            )
         } else if cfg!(feature = "vault") {
             let client = Vault::new(self.vault_config);
-            KeyManagerClient::new(Arc::new(client))
+            let client_arc = Arc::new(client);
+            KeyManagerClient::new(client_arc.clone(), client_arc)
         } else {
             let client = self.master_key;
-            KeyManagerClient::new(Arc::new(client))
+            let client_arc = Arc::new(client);
+            KeyManagerClient::new(client_arc.clone(), client_arc)
         }
     }
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -3,7 +3,7 @@ pub(crate) mod blake3;
 pub(crate) mod kms;
 pub(crate) mod vault;
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use masking::StrongSecret;
 use strum::{Display, EnumString};
@@ -115,24 +115,37 @@ pub type Backend = dyn KeyManagement + Send + Sync;
 
 #[derive(Clone)]
 pub struct KeyManagerClient {
-    client: Arc<Backend>,
+    encrypt_client: Arc<Backend>,
+    decrypt_client: Arc<Backend>,
 }
 
 impl KeyManagerClient {
-    pub fn new(client: Arc<Backend>) -> Self {
-        Self { client }
+    pub fn new(encrypt_client: Arc<Backend>, decrypt_client: Arc<Backend>) -> Self {
+        Self {
+            encrypt_client,
+            decrypt_client,
+        }
     }
 }
 
 impl KeyManagerClient {
-    pub fn client(&self) -> &Arc<Backend> {
-        &self.client
+    pub async fn generate_key(
+        &self,
+    ) -> CustomResult<(Source, StrongSecret<[u8; 32]>), errors::CryptoError> {
+        self.encrypt_client.generate_key().await
     }
-}
 
-impl Deref for KeyManagerClient {
-    type Target = Arc<Backend>;
-    fn deref(&self) -> &Self::Target {
-        self.client()
+    pub async fn encrypt_key(
+        &self,
+        input: StrongSecret<Vec<u8>>,
+    ) -> CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError> {
+        self.encrypt_client.encrypt_key(input).await
+    }
+
+    pub async fn decrypt_key(
+        &self,
+        input: StrongSecret<Vec<u8>>,
+    ) -> CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError> {
+        self.decrypt_client.decrypt_key(input).await
     }
 }

--- a/src/services/aws/config.rs
+++ b/src/services/aws/config.rs
@@ -1,14 +1,25 @@
 use aws_config::{BehaviorVersion, meta::region::RegionProviderChain};
 use aws_sdk_kms::{Client, config::Region};
 
-/// Configuration parameters required for constructing a [`AwsKmsClient`].
+/// Configuration parameters for KMS encryption operations.
 #[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq)]
 #[serde(default)]
-pub struct AwsKmsConfig {
-    /// The AWS key identifier of the KMS key used to encrypt or decrypt data.
+pub struct AwsKmsEncryptionConfig {
+    /// The AWS key identifier of the KMS key used to encrypt data.
     pub key_id: String,
 
-    /// The AWS region to send KMS requests to.
+    /// The AWS region to send KMS encryption requests to.
+    pub region: String,
+}
+
+/// Configuration parameters for KMS decryption operations.
+#[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct AwsKmsDecryptionConfig {
+    /// The AWS key identifier of the KMS key used to decrypt data.
+    pub key_id: String,
+
+    /// The AWS region to send KMS decryption requests to.
     pub region: String,
 
     /// When true, omits key_id from decryption requests, allowing KMS to determine the key from ciphertext metadata.
@@ -24,8 +35,8 @@ pub struct AwsKmsClient {
 }
 
 impl AwsKmsClient {
-    pub async fn new(config: &AwsKmsConfig) -> Self {
-        let region_provider = RegionProviderChain::first_try(Region::new(config.region.clone()));
+    async fn new_inner(key_id: String, region: String, skip_key_id_on_decrypt: bool) -> Self {
+        let region_provider = RegionProviderChain::first_try(Region::new(region));
         let sdk_config = aws_config::defaults(BehaviorVersion::v2024_03_28())
             .region(region_provider)
             .load()
@@ -33,9 +44,22 @@ impl AwsKmsClient {
 
         Self {
             inner_client: Client::new(&sdk_config),
-            key_id: config.key_id.clone(),
-            skip_key_id_on_decrypt: config.skip_key_id_on_decrypt,
+            key_id,
+            skip_key_id_on_decrypt,
         }
+    }
+
+    pub async fn new_for_encryption(config: &AwsKmsEncryptionConfig) -> Self {
+        Self::new_inner(config.key_id.clone(), config.region.clone(), false).await
+    }
+
+    pub async fn new_for_decryption(config: &AwsKmsDecryptionConfig) -> Self {
+        Self::new_inner(
+            config.key_id.clone(),
+            config.region.clone(),
+            config.skip_key_id_on_decrypt,
+        )
+        .await
     }
 
     pub fn inner_client(&self) -> &Client {


### PR DESCRIPTION
Files Modified
1. src/services/aws/config.rs — Split the config struct
- Removed: AwsKmsConfig (single shared config)
- Added: AwsKmsEncryptionConfig { key_id, region } — for encryption operations
- Added: AwsKmsDecryptionConfig { key_id, region, skip_key_id_on_decrypt } — for decryption operations
- AwsKmsClient::new() → new_for_encryption() / new_for_decryption() with a shared new_inner() helper
2. src/config.rs — Updated config wiring
- Secrets.kms_config → Secrets.kms_encryption_config + Secrets.kms_decryption_config
- Secrets::validate() now checks both configs independently
- Secrets::create_keymanager_client() creates two AwsKmsClient instances (one for encrypt, one for decrypt) and passes both to KeyManagerClient::new()
- SecretContainer::expose() uses kms_decryption_config (since it decrypts secrets)
3. src/crypto.rs — Restructured KeyManagerClient
- Now holds encrypt_client: Arc<Backend> + decrypt_client: Arc<Backend>
- Added explicit generate_key(), encrypt_key(), decrypt_key() methods (instead of Deref delegation)
- For non-KMS backends (AES, Vault), both clients point to the same Arc (no duplication)
4. config/development.toml — Added commented config examples
New Environment Variable Mapping
Old	New
CRIPTA__SECRETS__KMS_CONFIG__KEY_ID	CRIPTA__SECRETS__KMS_ENCRYPTION_CONFIG__KEY_ID + CRIPTA__SECRETS__KMS_DECRYPTION_CONFIG__KEY_ID
CRIPTA__SECRETS__KMS_CONFIG__REGION	CRIPTA__SECRETS__KMS_ENCRYPTION_CONFIG__REGION + CRIPTA__SECRETS__KMS_DECRYPTION_CONFIG__REGION
CRIPTA__SECRETS__KMS_CONFIG__SKIP_KEY_ID_ON_DECRYPT	CRIPTA__SECRETS__KMS_DECRYPTION_CONFIG__SKIP_KEY_ID_ON_DECRYPT