### PR TITLE
build(deps): pull `hyperswitch_masking` from crates.io instead of as a git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -540,7 +540,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "serde",
@@ -750,15 +750,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "charybdis"
-version = "0.7.9"
-source = "git+https://github.com/dracarys18/charybdis.git?rev=1637c263f512adf7840705e3ab405a113437a6e3#1637c263f512adf7840705e3ab405a113437a6e3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524df1543f20fbc48417dec5e179e7c043ff6dae68104eed323f671fe6189464"
 dependencies = [
  "bigdecimal",
  "charybdis_macros",
  "chrono",
  "colored",
  "futures",
- "num-bigint",
  "scylla",
  "serde",
  "serde_json",
@@ -767,20 +767,21 @@ dependencies = [
 
 [[package]]
 name = "charybdis_macros"
-version = "0.7.9"
-source = "git+https://github.com/dracarys18/charybdis.git?rev=1637c263f512adf7840705e3ab405a113437a6e3#1637c263f512adf7840705e3ab405a113437a6e3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee5d7873a087cfdb4b72cfdb3dcbb3011d8396596aaa7ec1f45afb4247c4e54"
 dependencies = [
  "charybdis_parser",
- "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "charybdis_parser"
-version = "0.7.9"
-source = "git+https://github.com/dracarys18/charybdis.git?rev=1637c263f512adf7840705e3ab405a113437a6e3#1637c263f512adf7840705e3ab405a113437a6e3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8946f45cac9b0cb3990155fa059db176aa58c3e5361f04990834a995c7f4e7dc"
 dependencies = [
  "colored",
  "darling 0.20.10",
@@ -789,9 +790,9 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
- "syn 2.0.91",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -873,11 +874,10 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
  "windows-sys 0.59.0",
 ]
 
@@ -999,7 +999,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper 1.5.2",
- "masking",
+ "hyperswitch_masking",
  "moka",
  "once_cell",
  "opentelemetry",
@@ -1017,7 +1017,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "strum",
+ "strum 0.26.3",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -1164,7 +1164,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1186,16 +1186,17 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1222,17 +1223,16 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1306,7 +1306,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1315,7 +1315,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1360,7 +1360,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1462,19 +1462,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1557,7 +1548,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1700,6 +1691,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1727,12 +1723,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "histogram"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hmac"
@@ -1910,6 +1900,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperswitch_masking"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d110ac2d2ce7a5f84c7172e710ca1241fd5ecec6e77aa83a85071b8d52e04f3"
+dependencies = [
+ "diesel",
+ "erased-serde",
+ "scylla",
+ "serde",
+ "serde_json",
+ "subtle",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,7 +1945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
  "zerovec",
 ]
@@ -2034,7 +2040,7 @@ dependencies = [
  "stable_deref_trait",
  "tinystr",
  "writeable",
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
  "zerovec",
 ]
@@ -2047,7 +2053,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2115,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2205,22 +2211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "masking"
-version = "0.1.0"
-source = "git+https://github.com/juspay/hyperswitch.git?tag=2024.12.17.0#886e2aacd7dcd8a04a33884ceafb1562aa7c365f"
-dependencies = [
- "diesel",
- "erased-serde",
- "scylla",
- "serde",
- "serde_json",
- "subtle",
- "time",
- "url",
- "zeroize",
 ]
 
 [[package]]
@@ -2331,6 +2321,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
@@ -2341,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2385,48 +2386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
-name = "openssl"
-version = "0.10.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.105"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2567,7 +2530,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2610,12 +2573,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -2700,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2796,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2870,11 +2827,11 @@ dependencies = [
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3253,64 +3210,83 @@ dependencies = [
 
 [[package]]
 name = "scylla"
-version = "0.15.0"
-source = "git+https://github.com/juspay/scylla-rust-driver.git?rev=5700aa2847b25437cdd4fcf34d707aa90dca8b89#5700aa2847b25437cdd4fcf34d707aa90dca8b89"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab73aaea18839882f43c08bc6367dfd1d4e9d285a2ab6ac4335b9dc06b63c19"
 dependencies = [
  "arc-swap",
  "async-trait",
- "byteorder",
  "bytes",
  "chrono",
  "dashmap",
  "futures",
- "hashbrown 0.14.5",
- "histogram",
- "itertools 0.13.0",
- "lazy_static",
- "lz4_flex",
- "openssl",
- "rand 0.8.5",
+ "hashbrown 0.15.2",
+ "itertools 0.14.0",
+ "rand 0.9.2",
  "rand_pcg",
  "scylla-cql",
- "scylla-macros",
  "smallvec",
- "snap",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "tokio",
- "tokio-openssl",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "scylla-cql"
-version = "0.4.0"
-source = "git+https://github.com/juspay/scylla-rust-driver.git?rev=5700aa2847b25437cdd4fcf34d707aa90dca8b89#5700aa2847b25437cdd4fcf34d707aa90dca8b89"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87834c927e9336270725aac24fada6e86f9d14aa04a8c8f93223b002e86f3891"
 dependencies = [
- "async-trait",
+ "bigdecimal",
  "byteorder",
  "bytes",
+ "chrono",
+ "itertools 0.14.0",
  "lz4_flex",
+ "num-bigint 0.3.3",
+ "num-bigint 0.4.6",
  "scylla-macros",
+ "secrecy 0.10.3",
+ "secrecy 0.8.0",
  "snap",
  "stable_deref_trait",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "time",
  "tokio",
  "uuid",
- "yoke",
+ "yoke 0.8.1",
 ]
 
 [[package]]
 name = "scylla-macros"
-version = "0.7.0"
-source = "git+https://github.com/juspay/scylla-rust-driver.git?rev=5700aa2847b25437cdd4fcf34d707aa90dca8b89#5700aa2847b25437cdd4fcf34d707aa90dca8b89"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad97e5f7ccd8a1d41e631e361c9851c21b093e15ff5dcd08861f6ac83215d434"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -3360,22 +3336,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3550,8 +3536,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -3563,7 +3555,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.91",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3585,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3623,7 +3627,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3658,7 +3662,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3669,7 +3673,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3684,30 +3688,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3775,7 +3779,7 @@ checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3804,18 +3808,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "tokio-openssl"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
-dependencies = [
- "openssl",
- "openssl-sys",
- "tokio",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4027,7 +4020,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4141,9 +4134,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -4324,7 +4317,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4359,7 +4352,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4626,7 +4619,18 @@ checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive 0.8.1",
  "zerofrom",
 ]
 
@@ -4638,7 +4642,19 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
+ "synstructure 0.13.1",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
  "synstructure 0.13.1",
 ]
 
@@ -4660,7 +4676,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4680,7 +4696,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
  "synstructure 0.13.1",
 ]
 
@@ -4701,7 +4717,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4710,7 +4726,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -4723,5 +4739,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ error-stack = "0.4.1"
 futures = "0.3.30"
 hex = "0.4.3"
 hyper = "1.3.1"
-masking = { version = "0.0.1", features = ["cassandra", "diesel", "serde"], package = "hyperswitch_masking" }
+hyperswitch_masking = { version = "0.0.1", features = ["cassandra", "diesel", "serde"] }
 moka = { version = "0.12", default-features = false, features = ["future"] }
 once_cell = "1.19.0"
 opentelemetry = { version = "0.29.1", features = ["metrics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 axum-server = "0.7.3"
 base64 = "0.22.1"
 cargo_metadata = "0.18.1"
-charybdis = { git = "https://github.com/dracarys18/charybdis.git", rev = "1637c263f512adf7840705e3ab405a113437a6e3" }
+charybdis = "1.1.0"
 config = { version = "0.14.0", features = ["toml"] }
 diesel = { version = "2.2.4", features = ["postgres", "serde_json", "time"] }
 diesel-async = { version = "0.5.2", features = ["postgres", "bb8"] }
@@ -30,7 +30,7 @@ error-stack = "0.4.1"
 futures = "0.3.30"
 hex = "0.4.3"
 hyper = "1.3.1"
-masking = { git = "https://github.com/juspay/hyperswitch.git", tag = "2024.12.17.0", features = ["cassandra"] }
+masking = { version = "0.0.1", features = ["cassandra", "diesel", "serde"], package = "hyperswitch_masking" }
 moka = { version = "0.12", default-features = false, features = ["future"] }
 once_cell = "1.19.0"
 opentelemetry = { version = "0.29.1", features = ["metrics"] }
@@ -43,13 +43,13 @@ rustc-hash = "1.1.0"
 rustls = { version = "0.23.10", default-features = false, features = ["std"], optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }
 rustls-pemfile = { version = "2.1.2", default-features = false, features = ["std"], optional = true }
-scylla = { git = "https://github.com/juspay/scylla-rust-driver.git", rev = "5700aa2847b25437cdd4fcf34d707aa90dca8b89", features = ["time-03"] }
-serde = { version = "1.0.202", features = ["derive"] }
+scylla = { version = "1.5.0", features = ["time-03"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.117"
 serde_path_to_error = "0.1.16"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "1.0.58"
-time = { version = "0.3.36", features = ["parsing"] }
+time = { version = "0.3.47", features = ["parsing"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.10", optional = true }
 tokio-postgres-rustls = { version = "0.13.0", optional = true }

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,7 +19,8 @@ use crate::{
 pub(crate) type StorageState = DbState<Pool<AsyncPgConnection>, adapter::PostgreSQL>;
 
 #[cfg(feature = "cassandra")]
-pub(crate) type StorageState = DbState<scylla::CachingSession, adapter::Cassandra>;
+pub(crate) type StorageState =
+    DbState<scylla::client::caching_session::CachingSession, adapter::Cassandra>;
 
 pub struct AppState {
     pub conf: Config,

--- a/src/app/tls.rs
+++ b/src/app/tls.rs
@@ -1,6 +1,6 @@
 use std::{io, sync::Arc};
 
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 use rustls::{ServerConfig, pki_types::CertificateDer, server::WebPkiClientVerifier};
 
 use crate::config::Config;

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -22,7 +22,7 @@ async fn main() {
 
     let _guard = observability::setup(&config.log, [], env!("CARGO_BIN_NAME"));
 
-    let host: SocketAddr = format!("{}:{}", &config.server.host, config.server.port)
+    let host: SocketAddr = format!("{}:{}", config.server.host, config.server.port)
         .parse()
         .expect("Unable to parse host");
 
@@ -86,7 +86,7 @@ async fn main() {
 async fn spawn_metrics_server(state: Arc<AppState>) {
     let host: SocketAddr = format!(
         "{}:{}",
-        &state.conf.metrics_server.host, &state.conf.metrics_server.port
+        state.conf.metrics_server.host, state.conf.metrics_server.port
     )
     .parse()
     .expect("Unable to parse metrics server");

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
 
 use aws_sdk_kms::primitives::Blob;
 use config::File;
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use vaultrs::{
@@ -50,14 +50,14 @@ impl Environment {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct SecretContainer(masking::Secret<String>);
+pub struct SecretContainer(hyperswitch_masking::Secret<String>);
 
 impl SecretContainer {
     /// # Panics
     ///
     /// Panics when secret cannot be decrypted with KMS
     #[allow(clippy::expect_used, unused_variables)]
-    pub async fn expose(&self, config: &Config) -> masking::Secret<String> {
+    pub async fn expose(&self, config: &Config) -> hyperswitch_masking::Secret<String> {
         if cfg!(feature = "aws") {
             use base64::Engine;
 
@@ -82,7 +82,7 @@ impl SecretContainer {
                 .into_inner();
 
             let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
-            masking::Secret::new(secret)
+            hyperswitch_masking::Secret::new(secret)
         } else if cfg!(feature = "vault") {
             use base64::Engine;
 
@@ -108,7 +108,7 @@ impl SecretContainer {
             .expect("Failed while decrypting vault encrypted secret")
             .plaintext;
 
-            masking::Secret::new(
+            hyperswitch_masking::Secret::new(
                 String::from_utf8(
                     crate::consts::base64::BASE64_ENGINE
                         .decode(b64_encoded_str)
@@ -168,9 +168,9 @@ pub struct Cassandra {
 pub struct Database {
     pub port: u16,
     pub host: String,
-    pub user: masking::Secret<String>,
+    pub user: hyperswitch_masking::Secret<String>,
     pub password: SecretContainer,
-    pub dbname: masking::Secret<String>,
+    pub dbname: hyperswitch_masking::Secret<String>,
     pub pool_size: Option<u32>,
     pub min_idle: Option<u32>,
     pub enable_ssl: Option<bool>,

--- a/src/core/crypto/crux.rs
+++ b/src/core/crypto/crux.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 

--- a/src/core/datakey/transfer.rs
+++ b/src/core/datakey/transfer.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use error_stack::ResultExt;
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 
 use crate::{
     consts::base64::BASE64_ENGINE,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,7 +4,7 @@ pub(crate) mod vault;
 
 use std::{ops::Deref, sync::Arc};
 
-use masking::StrongSecret;
+use hyperswitch_masking::StrongSecret;
 use strum::{Display, EnumString};
 
 use crate::{

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use error_stack::ResultExt;
-use masking::{PeekInterface, StrongSecret};
+use hyperswitch_masking::{PeekInterface, StrongSecret};
 use ring::aead::{self, BoundKey, OpeningKey, SealingKey, UnboundKey};
 use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
 

--- a/src/crypto/kms.rs
+++ b/src/crypto/kms.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use aws_sdk_kms::primitives::Blob;
 use futures::Future;
-use masking::{PeekInterface, StrongSecret};
+use hyperswitch_masking::{PeekInterface, StrongSecret};
 
 use crate::{
     crypto::{Crypto, Source},

--- a/src/crypto/vault.rs
+++ b/src/crypto/vault.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use base64::Engine;
 use error_stack::report;
 use futures::Future;
-use masking::{PeekInterface, StrongSecret};
+use hyperswitch_masking::{PeekInterface, StrongSecret};
 use serde::Deserialize;
 use vaultrs::{
     api,
@@ -23,7 +23,7 @@ pub struct VaultSettings {
     pub url: String,
     pub mount_point: String,
     pub encryption_key: String,
-    pub vault_token: masking::Secret<String>,
+    pub vault_token: hyperswitch_masking::Secret<String>,
 }
 
 pub struct Vault {

--- a/src/storage/adapter/cassandra.rs
+++ b/src/storage/adapter/cassandra.rs
@@ -3,16 +3,16 @@ mod dek;
 use crate::storage::{Config, DbState, adapter::Cassandra, errors};
 
 #[async_trait::async_trait]
-impl super::DbAdapter for DbState<scylla::CachingSession, Cassandra> {
-    type Conn<'a> = &'a scylla::CachingSession;
+impl super::DbAdapter for DbState<scylla::client::caching_session::CachingSession, Cassandra> {
+    type Conn<'a> = &'a scylla::client::caching_session::CachingSession;
     type AdapterType = Cassandra;
-    type Pool = scylla::CachingSession;
+    type Pool = scylla::client::caching_session::CachingSession;
 
     #[allow(clippy::expect_used)]
     async fn from_config(config: &Config, schema: &str) -> Self {
-        let session = scylla::SessionBuilder::new()
+        let session = scylla::client::session_builder::SessionBuilder::new()
             .known_nodes(&config.cassandra.known_nodes)
-            .pool_size(scylla::transport::session::PoolSize::PerHost(
+            .pool_size(scylla::client::PoolSize::PerHost(
                 config.cassandra.pool_size,
             ))
             .use_keyspace(schema, false)
@@ -22,7 +22,10 @@ impl super::DbAdapter for DbState<scylla::CachingSession, Cassandra> {
 
         Self {
             _adapter: std::marker::PhantomData,
-            pool: scylla::CachingSession::from(session, config.cassandra.cache_size),
+            pool: scylla::client::caching_session::CachingSession::from(
+                session,
+                config.cassandra.cache_size,
+            ),
         }
     }
 

--- a/src/storage/adapter/cassandra/dek.rs
+++ b/src/storage/adapter/cassandra/dek.rs
@@ -8,19 +8,21 @@ use crate::{
     storage::{
         adapter::Cassandra,
         dek::DataKeyStorageInterface,
-        types::{DataKey, DataKeyNew},
+        types::{CassandraDataKey, DataKey, DataKeyNew},
     },
     types::{Identifier, key::Version},
 };
 
 #[async_trait::async_trait]
-impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
+impl DataKeyStorageInterface
+    for DbState<scylla::client::caching_session::CachingSession, Cassandra>
+{
     async fn get_or_insert_data_key(
         &self,
         new: DataKeyNew,
     ) -> CustomResult<DataKey, errors::DatabaseError> {
         let connection = self.get_conn().await.switch()?;
-        let key: DataKey = new.into();
+        let key = CassandraDataKey::from(DataKey::from(new));
 
         let find_query = self
             .get_key(
@@ -42,7 +44,7 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
                     .execute(connection)
                     .await
                     .switch()?;
-                Ok(key)
+                Ok(DataKey::from(key))
             }
         }
     }
@@ -54,11 +56,12 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
         let (data_id, key_id) = identifier.get_identifier();
         let connection = self.get_conn().await.switch()?;
 
-        let data_key = DataKey::find_first_by_key_identifier_and_data_identifier(key_id, data_id)
-            .consistency(scylla::statement::Consistency::LocalQuorum)
-            .execute(connection)
-            .await
-            .switch()?;
+        let data_key =
+            CassandraDataKey::find_first_by_key_identifier_and_data_identifier(key_id, data_id)
+                .consistency(scylla::statement::Consistency::LocalQuorum)
+                .execute(connection)
+                .await
+                .switch()?;
 
         Ok(data_key.version)
     }
@@ -71,13 +74,14 @@ impl DataKeyStorageInterface for DbState<scylla::CachingSession, Cassandra> {
         let (data_id, key_id) = identifier.get_identifier();
         let connection = self.get_conn().await.switch()?;
 
-        let data_key =
-            DataKey::find_by_key_identifier_and_data_identifier_and_version(key_id, data_id, v)
-                .consistency(scylla::statement::Consistency::LocalQuorum)
-                .execute(connection)
-                .await
-                .switch()?;
+        let data_key = CassandraDataKey::find_by_key_identifier_and_data_identifier_and_version(
+            key_id, data_id, v,
+        )
+        .consistency(scylla::statement::Consistency::LocalQuorum)
+        .execute(connection)
+        .await
+        .switch()?;
 
-        Ok(data_key)
+        Ok(DataKey::from(data_key))
     }
 }

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -7,7 +7,7 @@ use diesel_async::{
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig, bb8::Pool},
 };
 use error_stack::ResultExt;
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 
 use crate::storage::{Config, Connection, DbState, adapter::PostgreSQL, errors};
 

--- a/src/storage/types/dek.rs
+++ b/src/storage/types/dek.rs
@@ -1,7 +1,7 @@
 use charybdis::macros::charybdis_model;
 use diesel::{Identifiable, Insertable, Queryable};
 use masking::StrongSecret;
-use time::PrimitiveDateTime;
+use time::{OffsetDateTime, PrimitiveDateTime};
 
 use crate::{schema::data_key_store, types::key::Version};
 
@@ -16,15 +16,6 @@ pub struct DataKeyNew {
     pub source: String,
 }
 
-#[charybdis_model(
-    table_name = data_key_store,
-    partition_keys = [key_identifier, data_identifier],
-    clustering_keys = [version],
-    table_options = r#"
-          CLUSTERING ORDER BY (version DESC)
-          AND gc_grace_seconds = 86400
-      "#
-)]
 #[derive(Queryable, Identifiable)]
 #[diesel(table_name = data_key_store)]
 pub struct DataKey {
@@ -35,6 +26,58 @@ pub struct DataKey {
     pub version: Version,
     pub created_at: PrimitiveDateTime,
     pub source: String,
+}
+
+// Cassandra representation of `DataKey`.
+//
+// This uses `OffsetDateTime` because Scylla does not support the required
+// traits for `PrimitiveDateTime`.
+#[charybdis_model(
+    table_name = data_key_store,
+    partition_keys = [key_identifier, data_identifier],
+    clustering_keys = [version],
+    table_options = r#"
+          CLUSTERING ORDER BY (version DESC)
+          AND gc_grace_seconds = 86400
+      "#
+)]
+pub struct CassandraDataKey {
+    pub id: i32,
+    pub key_identifier: String,
+    pub data_identifier: String,
+    pub encryption_key: StrongSecret<Vec<u8>>,
+    pub version: Version,
+    pub created_at: OffsetDateTime,
+    pub source: String,
+}
+
+impl From<CassandraDataKey> for DataKey {
+    fn from(value: CassandraDataKey) -> Self {
+        let utc_created_at = value.created_at.to_utc();
+        Self {
+            id: value.id,
+            key_identifier: value.key_identifier,
+            data_identifier: value.data_identifier,
+            encryption_key: value.encryption_key,
+            version: value.version,
+            created_at: PrimitiveDateTime::new(utc_created_at.date(), utc_created_at.time()),
+            source: value.source,
+        }
+    }
+}
+
+impl From<DataKey> for CassandraDataKey {
+    fn from(value: DataKey) -> Self {
+        Self {
+            id: value.id,
+            key_identifier: value.key_identifier,
+            data_identifier: value.data_identifier,
+            encryption_key: value.encryption_key,
+            version: value.version,
+            created_at: value.created_at.assume_utc(),
+            source: value.source,
+        }
+    }
 }
 
 impl From<DataKeyNew> for DataKey {

--- a/src/storage/types/dek.rs
+++ b/src/storage/types/dek.rs
@@ -1,6 +1,6 @@
 use charybdis::macros::charybdis_model;
 use diesel::{Identifiable, Insertable, Queryable};
-use masking::StrongSecret;
+use hyperswitch_masking::StrongSecret;
 use time::{OffsetDateTime, PrimitiveDateTime};
 
 use crate::{schema::data_key_store, types::key::Version};

--- a/src/types/core/data.rs
+++ b/src/types/core/data.rs
@@ -93,7 +93,7 @@ impl Serialize for EncryptedData {
         S: serde::Serializer,
     {
         let data = BASE64_ENGINE.encode(self.data.peek());
-        let encoded = format!("{}:{}", &self.version, data);
+        let encoded = format!("{}:{}", self.version, data);
         serializer.serialize_str(&encoded)
     }
 }

--- a/src/types/core/data.rs
+++ b/src/types/core/data.rs
@@ -169,7 +169,9 @@ mod tests {
         let actual_data: ExtractedEncryptedData = serde_json::from_value(data).unwrap();
         let expected_data = EncryptedData {
             version: Version::from(1),
-            data: hyperswitch_masking::StrongSecret::new(String::from("Omgit'sworking").as_bytes().to_vec()),
+            data: hyperswitch_masking::StrongSecret::new(
+                String::from("Omgit'sworking").as_bytes().to_vec(),
+            ),
         };
 
         let expected_data = ExtractedEncryptedData {

--- a/src/types/core/data.rs
+++ b/src/types/core/data.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use base64::engine::Engine;
-use masking::PeekInterface;
+use hyperswitch_masking::PeekInterface;
 use rustc_hash::FxHashMap;
 use serde::{
     Serialize,
@@ -17,14 +17,14 @@ pub struct MultipleDecryptionDataGroup(pub Vec<DecryptedDataGroup>);
 pub struct DecryptedDataGroup(pub FxHashMap<String, DecryptedData>);
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct DecryptedData(masking::StrongSecret<Vec<u8>>);
+pub struct DecryptedData(hyperswitch_masking::StrongSecret<Vec<u8>>);
 
 impl DecryptedData {
-    pub fn from_data(data: masking::StrongSecret<Vec<u8>>) -> Self {
+    pub fn from_data(data: hyperswitch_masking::StrongSecret<Vec<u8>>) -> Self {
         Self(data)
     }
 
-    pub fn inner(self) -> masking::StrongSecret<Vec<u8>> {
+    pub fn inner(self) -> hyperswitch_masking::StrongSecret<Vec<u8>> {
         self.0
     }
 }
@@ -79,11 +79,11 @@ pub struct EncryptedDataGroup(pub FxHashMap<String, EncryptedData>);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EncryptedData {
     pub version: Version,
-    pub data: masking::StrongSecret<Vec<u8>>,
+    pub data: hyperswitch_masking::StrongSecret<Vec<u8>>,
 }
 
 impl EncryptedData {
-    pub fn inner(self) -> masking::StrongSecret<Vec<u8>> {
+    pub fn inner(self) -> hyperswitch_masking::StrongSecret<Vec<u8>> {
         self.data
     }
 }
@@ -141,7 +141,7 @@ impl<'de> Deserialize<'de> for EncryptedData {
 
                 Ok(EncryptedData {
                     version: Version::from(version),
-                    data: masking::StrongSecret::new(dec_data),
+                    data: hyperswitch_masking::StrongSecret::new(dec_data),
                 })
             }
         }
@@ -169,7 +169,7 @@ mod tests {
         let actual_data: ExtractedEncryptedData = serde_json::from_value(data).unwrap();
         let expected_data = EncryptedData {
             version: Version::from(1),
-            data: masking::StrongSecret::new(String::from("Omgit'sworking").as_bytes().to_vec()),
+            data: hyperswitch_masking::StrongSecret::new(String::from("Omgit'sworking").as_bytes().to_vec()),
         };
 
         let expected_data = ExtractedEncryptedData {

--- a/src/types/core/key.rs
+++ b/src/types/core/key.rs
@@ -9,7 +9,7 @@ use diesel::{
     serialize::ToSql,
     sql_types,
 };
-use masking::{Deserialize, Serialize, StrongSecret};
+use hyperswitch_masking::{Deserialize, Serialize, StrongSecret};
 use rustc_hash::{FxHashMap, FxHashSet};
 use scylla::{
     deserialize::{FrameSlice, value::DeserializeValue},

--- a/src/types/core/key.rs
+++ b/src/types/core/key.rs
@@ -12,7 +12,7 @@ use diesel::{
 use masking::{Deserialize, Serialize, StrongSecret};
 use rustc_hash::{FxHashMap, FxHashSet};
 use scylla::{
-    deserialize::{DeserializeValue, FrameSlice},
+    deserialize::{FrameSlice, value::DeserializeValue},
     frame::response::result::ColumnType,
 };
 use serde::de::{self, Deserializer, Unexpected, Visitor};

--- a/src/types/requests/data_key.rs
+++ b/src/types/requests/data_key.rs
@@ -18,5 +18,5 @@ pub struct RotateDataKeyRequest {
 pub struct TransferKeyRequest {
     #[serde(flatten)]
     pub identifier: Identifier,
-    pub key: masking::StrongSecret<String>,
+    pub key: hyperswitch_masking::StrongSecret<String>,
 }


### PR DESCRIPTION
### Description

This PR pulls the `masking` crate (which is now published as `hyperswitch_masking`) from crates.io instead of pulling it as a git dependency from the `juspay/hyperswitch` repository.

Additionally, this PR also bumps:

- The `serde` crate version to `1.0.228`, as required by the current version of the `hyperswitch_masking` crate (see https://github.com/juspay/framework-libs-rs/pull/8)
- The `charybdis` crate version to `1.1.0` from crates.io instead of pulling from a fork.
- The `scylla` crate version to `1.5.0` from crates.io instead of pulling from a fork.

Because we're now pulling `scylla` and `charybdis` crates from crates.io and not the fork (which previously implemented some traits on `time::PrimitiveDateTime`, this PR introduces a `CassandraDataKey` type which uses `OffsetDateTime` instead of `PrimitiveDateTime` for the timestamp field, while the database type `DataKey` still uses `PrimitiveDateTime`. `From` impls to convert between the two have been added as well. All Cassandra related impls of `DataKey` now use the `CassandraDataKey` type.

Lastly, this PR also addresses clippy lints from Rust 1.97.0.