### PR TITLE
 refactor(postgres): allow configuring pool and connection timeouts 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ aws = []
 vergen = ["build_info/vergen-gix", "build_info/vergen-gix-build"]
 release = ["aws", "mtls", "postgres_ssl", "vergen"]
 vault = []
-postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres", "dep:tokio-postgres-rustls", "rustls/aws_lc_rs"]
+postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pemfile", "dep:tokio-postgres-rustls", "rustls/aws_lc_rs"]
 cassandra = []
 
 [dependencies]
@@ -49,7 +49,7 @@ strum = { version = "0.28", features = ["derive"] }
 thiserror = "2.0.18"
 time = { version = "0.3.53", features = ["parsing"] }
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
-tokio-postgres = { version = "0.7.18", optional = true }
+tokio-postgres = { version = "0.7.18" }
 tokio-postgres-rustls = { version = "0.14.0", optional = true }
 tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["trace", "request-id", "util", "set-header"] }

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -8,20 +8,25 @@ port = 5000        # Port the HTTP server listens on. Use a port that does not c
 
 # Database configuration
 [database]
-host = "localhost"       # Database hostname or IP address
-port = 5432              # Database port
-user = "db_user"         # Username for database authentication
-password = "db_pass"     # Database password.
-                         # Must be a base64-encoded KMS ciphertext when the `aws` compile-time feature flag is enabled.
-                         # The output of `aws kms encrypt` command (the CiphertextBlob field) can be used directly as this value.
-dbname = "encryption_db" # Name of the database
-pool_size = 5            # Maximum number of connections in the pool (optional, default: none)
-min_idle = 2             # Minimum number of idle connections to maintain (optional, default: none)
-enable_ssl = false       # Enable or disable TLS for database connections (optional, default: false).
-                         # Requires the `postgres_ssl` compile-time feature flag.
-# root_ca = ""           # Path to a custom root CA certificate for database TLS (optional).
-                         # Only used when enable_ssl is true and the `postgres_ssl` feature is enabled.
-                         # Must be a base64-encoded KMS ciphertext when the `aws` feature is enabled.
+host = "localhost"                   # Database hostname or IP address
+port = 5432                          # Database port
+user = "db_user"                     # Username for database authentication
+password = "db_pass"                 # Database password.
+                                     # Must be a base64-encoded KMS ciphertext when the `aws` compile-time feature flag is enabled.
+                                     # The output of `aws kms encrypt` command (the CiphertextBlob field) can be used directly as this value.
+dbname = "encryption_db"             # Name of the database
+pool_size = 5                        # Maximum number of connections in the pool (optional, default: none)
+min_idle = 2                         # Minimum number of idle connections to maintain (optional, default: none)
+enable_ssl = false                   # Enable or disable TLS for database connections (optional, default: false).
+                                     # Requires the `postgres_ssl` compile-time feature flag.
+# root_ca = ""                       # Path to a custom root CA certificate for database TLS (optional).
+                                     # Only used when enable_ssl is true and the `postgres_ssl` feature is enabled.
+                                     # Must be a base64-encoded KMS ciphertext when the `aws` feature is enabled.
+max_lifetime_secs = 1800             # Max connection lifetime in seconds (optional).
+                                     # Connections older than this are closed by the pool reaper.
+idle_timeout_secs = 600              # Close idle connections beyond `min_idle` after this duration in seconds (optional).
+connection_acquire_timeout_secs = 30 # Duration in seconds to wait for a connection to be acquired from the pool (optional).
+connect_timeout_secs = 5             # Per-socket TCP connection timeout in seconds (optional).
 
 # Thread pool configuration
 [pool_config]

--- a/config/development.toml
+++ b/config/development.toml
@@ -19,6 +19,10 @@ dbname = "encryption_db"
 pool_size = 5
 min_idle = 2
 enable_ssl = false
+max_lifetime_secs = 1800
+idle_timeout_secs = 600
+connection_acquire_timeout_secs = 30
+connect_timeout_secs = 5
 
 [multitenancy.tenants.public]
 schema = "public"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,8 @@
-use std::{num::NonZeroUsize, path::PathBuf, sync::Arc};
+use std::{
+    num::{NonZeroU64, NonZeroUsize},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use aws_sdk_kms::primitives::Blob;
 use config::File;
@@ -177,6 +181,10 @@ pub struct Database {
     pub min_idle: Option<u32>,
     pub enable_ssl: Option<bool>,
     pub root_ca: Option<SecretContainer>,
+    pub max_lifetime_secs: Option<NonZeroU64>,
+    pub idle_timeout_secs: Option<NonZeroU64>,
+    pub connection_acquire_timeout_secs: Option<NonZeroU64>,
+    pub connect_timeout_secs: Option<NonZeroU64>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -1,15 +1,49 @@
 mod dek;
 
-#[cfg(feature = "postgres_ssl")]
 use diesel::ConnectionError;
 use diesel_async::{
     AsyncPgConnection,
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig, bb8::Pool},
 };
 use error_stack::ResultExt;
-use hyperswitch_masking::PeekInterface;
+use hyperswitch_masking::{ExposeInterface, PeekInterface};
 
 use crate::storage::{Config, Connection, DbState, adapter::PostgreSQL, errors};
+
+fn no_tls_custom_setup(
+    pg_config: tokio_postgres::Config,
+) -> diesel_async::pooled_connection::SetupCallback<AsyncPgConnection> {
+    Box::new(move |_url| {
+        let pg_config = pg_config.clone();
+        Box::pin(async move {
+            let (client, conn) = pg_config
+                .connect(tokio_postgres::NoTls)
+                .await
+                .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+            AsyncPgConnection::try_from_client_and_connection(client, conn).await
+        })
+    })
+}
+
+// We're accepting a decrypted password separately instead of reading the encrypted password from
+// the database config and decrypting it.
+// It helps keep this function pure, sync and infallible.
+fn build_pg_config(
+    database: &crate::config::Database,
+    schema: &str,
+    password: hyperswitch_masking::Secret<String>,
+) -> tokio_postgres::Config {
+    let mut pg_config = tokio_postgres::Config::new();
+    pg_config.host(database.host.clone());
+    pg_config.port(database.port);
+    pg_config.user(database.user.peek().clone());
+    pg_config.password(password.expose());
+    pg_config.dbname(database.dbname.peek().clone());
+    pg_config.application_name(schema);
+    pg_config.options(format!("-c search_path={schema}"));
+
+    pg_config
+}
 
 #[async_trait::async_trait]
 impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
@@ -24,21 +58,18 @@ impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
     async fn from_config(config: &Config, schema: &str) -> Self {
         let database = &config.database;
         let password = database.password.expose(config).await;
+        let pg_config = build_pg_config(database, schema, password);
+
+        // Minimal URL passed to `AsyncDieselConnectionManager::new_with_config()`,
+        // our `custom_setup` closure currently ignores the URL.
         let database_url = format!(
-            "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c search_path%3D{}",
+            "postgres://{}@{}:{}/{}",
             database.user.peek(),
-            password.peek(),
             database.host,
             database.port,
             database.dbname.peek(),
-            schema,
-            schema
         );
 
-        #[cfg(not(feature = "postgres_ssl"))]
-        let mgr_config = ManagerConfig::default();
-
-        #[cfg(feature = "postgres_ssl")]
         let mut mgr_config = ManagerConfig::default();
 
         #[cfg(feature = "postgres_ssl")]
@@ -49,28 +80,36 @@ impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
                 .expect("Failed to load db server root cert from the config")
                 .expose(config)
                 .await;
-            mgr_config.custom_setup = Box::new(move |config: &str| {
-                Box::pin({
-                    let root_ca = root_ca.clone();
-                    async move {
-                        let mut root_certificate = rustls::RootCertStore::empty();
-                        for cert in rustls_pemfile::certs(&mut root_ca.peek().as_ref()) {
-                            root_certificate
-                                .add(cert.expect("Failed to load db server root cert"))
-                                .expect("Failed to add cert to RootCertStore");
-                        }
-                        let rustls_config = rustls::ClientConfig::builder()
-                            .with_root_certificates(root_certificate)
-                            .with_no_client_auth();
-                        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-                        let (client, conn) = tokio_postgres::connect(config, tls)
-                            .await
-                            .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+            let pg_config_for_closure = pg_config.clone();
 
-                        AsyncPgConnection::try_from_client_and_connection(client, conn).await
+            mgr_config.custom_setup = Box::new(move |_url| {
+                let pg_config = pg_config_for_closure.clone();
+                let root_ca = root_ca.clone();
+                Box::pin(async move {
+                    let mut root_certificate = rustls::RootCertStore::empty();
+                    for cert in rustls_pemfile::certs(&mut root_ca.peek().as_ref()) {
+                        root_certificate
+                            .add(cert.expect("Failed to load db server root cert"))
+                            .expect("Failed to add cert to RootCertStore");
                     }
+                    let rustls_config = rustls::ClientConfig::builder()
+                        .with_root_certificates(root_certificate)
+                        .with_no_client_auth();
+                    let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
+                    let (client, conn) = pg_config
+                        .connect(tls)
+                        .await
+                        .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+                    AsyncPgConnection::try_from_client_and_connection(client, conn).await
                 })
             });
+        } else {
+            mgr_config.custom_setup = no_tls_custom_setup(pg_config);
+        }
+
+        #[cfg(not(feature = "postgres_ssl"))]
+        {
+            mgr_config.custom_setup = no_tls_custom_setup(pg_config);
         }
 
         let mgr = AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -41,6 +41,9 @@ fn build_pg_config(
     pg_config.dbname(database.dbname.peek().clone());
     pg_config.application_name(schema);
     pg_config.options(format!("-c search_path={schema}"));
+    if let Some(connect_timeout) = database.connect_timeout_secs {
+        pg_config.connect_timeout(std::time::Duration::from_secs(connect_timeout.get()));
+    }
 
     pg_config
 }
@@ -116,9 +119,26 @@ impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
             database_url,
             mgr_config,
         );
-        let pool = Pool::builder()
+
+        let mut pool_builder = Pool::builder()
             .max_size(database.pool_size.unwrap_or(10))
-            .min_idle(database.min_idle)
+            .min_idle(database.min_idle);
+
+        if let Some(max_lifetime) = database.max_lifetime_secs {
+            pool_builder =
+                pool_builder.max_lifetime(std::time::Duration::from_secs(max_lifetime.get()));
+        }
+        if let Some(idle_timeout) = database.idle_timeout_secs {
+            pool_builder =
+                pool_builder.idle_timeout(std::time::Duration::from_secs(idle_timeout.get()));
+        }
+        if let Some(connection_acquire_timeout) = database.connection_acquire_timeout_secs {
+            pool_builder = pool_builder.connection_timeout(std::time::Duration::from_secs(
+                connection_acquire_timeout.get(),
+            ));
+        }
+
+        let pool = pool_builder
             .build(mgr)
             .await
             .expect("Failed to establish pool connection");


### PR DESCRIPTION
### Description

This PR adds optional PostgreSQL connection and pool lifecycle settings:

- `max_lifetime_secs`
- `idle_timeout_secs`
- `connection_acquire_timeout_secs`
- `connect_timeout_secs`

Values for all of the above configs must be positive integers and fall back to library defaults when omitted.

Additionally, the connection setup now uses `tokio_postgres::Config`, to allow passing `connect_timeout` to `tokio-postgres` when creating the TCP connection. A result of this change is that we now no longer include passwords in the connection string.

### Testing

- Added temporary logs to be printed whenever a connection is created, and set `max_lifetime_secs` to 30 seconds. I'm able to see the "database connection created" logs every 30 seconds, printed 4 times every 30 seconds (2 idle connections * 2 tenants, `public` and `global` = 4 logs).
- Configured `idle_timeout_secs` to be 10 seconds, subjected the application to some load (via Postman), able to see that connections in the pool dropped to the `min_idle` number after the idle timeout duration.