### PR TITLE
feat(metrics): add postgres pool connection lifecycle counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "build_info"
 version = "0.1.0"
-source = "git+https://github.com/juspay/framework-libs-rs?rev=ba61fc2e40bde29e6fabbec0c592404bb4151738#ba61fc2e40bde29e6fabbec0c592404bb4151738"
+source = "git+https://github.com/juspay/framework-libs-rs?rev=3cdcc24b461917b29641942b04f3aef8110b1adf#3cdcc24b461917b29641942b04f3aef8110b1adf"
 dependencies = [
  "cargo_metadata",
  "vergen-gix",
@@ -3558,7 +3558,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 [[package]]
 name = "log_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/framework-libs-rs?rev=ba61fc2e40bde29e6fabbec0c592404bb4151738#ba61fc2e40bde29e6fabbec0c592404bb4151738"
+source = "git+https://github.com/juspay/framework-libs-rs?rev=3cdcc24b461917b29641942b04f3aef8110b1adf#3cdcc24b461917b29641942b04f3aef8110b1adf"
 dependencies = [
  "gethostname",
  "rustc-hash",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "metrics_utils"
 version = "0.1.0"
-source = "git+https://github.com/juspay/framework-libs-rs?rev=ba61fc2e40bde29e6fabbec0c592404bb4151738#ba61fc2e40bde29e6fabbec0c592404bb4151738"
+source = "git+https://github.com/juspay/framework-libs-rs?rev=3cdcc24b461917b29641942b04f3aef8110b1adf#3cdcc24b461917b29641942b04f3aef8110b1adf"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ aws-sdk-kms = { version = "1.111.0" }
 axum = { version = "0.8.9", features = ["macros"] }
 axum-server = "0.8.0"
 base64 = "0.23.1"
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "ba61fc2e40bde29e6fabbec0c592404bb4151738", features = ["cargo-workspace", "framework-libs-members-env"] }
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", features = ["cargo-workspace", "framework-libs-members-env"] }
 charybdis = "1.1.0"
 config = { version = "0.15.25", features = ["toml"] }
 diesel = { version = "2.3.12", features = ["postgres", "serde_json", "time"] }
@@ -32,8 +32,8 @@ futures = "0.3.34"
 hex = "0.4.3"
 hyper = "1.11.0"
 hyperswitch_masking = { version = "0.0.1", features = ["cassandra", "diesel", "serde"] }
-log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "ba61fc2e40bde29e6fabbec0c592404bb4151738", features = ["tracing"] }
-metrics_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "ba61fc2e40bde29e6fabbec0c592404bb4151738", features = ["opentelemetry-otlp", "opentelemetry-otlp-zstd", "opentelemetry-prometheus"] }
+log_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", features = ["tracing"] }
+metrics_utils = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", features = ["opentelemetry-otlp", "opentelemetry-otlp-zstd", "opentelemetry-prometheus"] }
 moka = { version = "0.12", default-features = false, features = ["future"] }
 rayon = "1.12.0"
 ring = { version = "0.17.14", features = ["std"] }
@@ -63,7 +63,7 @@ criterion = "0.8.2"
 rand = "0.10.2"
 
 [build-dependencies]
-build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "ba61fc2e40bde29e6fabbec0c592404bb4151738", features = ["cargo-workspace-build"] }
+build_info = { git = "https://github.com/juspay/framework-libs-rs", rev = "3cdcc24b461917b29641942b04f3aef8110b1adf", features = ["cargo-workspace-build"] }
 
 [profile.release]
 strip = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,9 +32,12 @@ impl AppState {
         let mut tenants = FxHashMap::default();
 
         for (tenant_id, tenant) in &config.multitenancy.tenants.0 {
+            let tenant_id = TenantId::new(tenant_id.clone());
             tenants.insert(
-                TenantId::new(tenant_id.clone()),
-                TenantState::new(Arc::new(SessionState::from_config(&config, tenant).await)),
+                tenant_id.clone(),
+                TenantState::new(Arc::new(
+                    SessionState::from_config(&config, &tenant_id, tenant).await,
+                )),
             );
         }
 
@@ -57,9 +60,13 @@ impl SessionState {
     ///
     /// Panics if failed to build thread pool
     #[allow(clippy::expect_used)]
-    pub async fn from_config(config: &Config, tenant_config: &TenantConfig) -> Self {
+    pub async fn from_config(
+        config: &Config,
+        tenant_id: &TenantId,
+        tenant_config: &TenantConfig,
+    ) -> Self {
         let secrets = config.secrets.clone();
-        let db_pool = StorageState::from_config(config, &tenant_config.schema).await;
+        let db_pool = StorageState::from_config(config, tenant_id, &tenant_config.schema).await;
         let num_threads = config.pool_config.pool;
 
         Self {

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::panic, clippy::expect_used)]
-
 use std::{net::SocketAddr, sync::Arc};
 
 use axum::{Router, body::Body};
@@ -23,6 +21,7 @@ fn default_headers() -> tower_http::set_header::SetResponseHeaderLayer<axum::htt
     )
 }
 
+#[expect(clippy::expect_used)]
 #[tokio::main]
 async fn main() {
     let config = config::Config::with_config_path(config::Environment::which(), None);
@@ -118,6 +117,7 @@ async fn main() {
         use axum_server::tls_rustls::RustlsConfig;
         use cripta::app::tls;
 
+        #[expect(clippy::panic)]
         let tls = tls::from_config(&state.conf)
             .await
             .unwrap_or_else(|err| panic!("unable to read the certificates. got err:{err:?}"));

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -23,7 +23,6 @@ impl GcmAes256 {
         Ok(Self { key })
     }
 
-    #[allow(dead_code)]
     pub async fn from_vec(
         key: StrongSecret<Vec<u8>>,
     ) -> errors::CustomResult<Self, errors::CryptoError> {

--- a/src/multitenancy.rs
+++ b/src/multitenancy.rs
@@ -12,13 +12,18 @@ use crate::{
 
 pub type MultiTenant<T> = FxHashMap<TenantId, T>;
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct TenantId(String);
 
 impl TenantId {
     pub fn new(val: String) -> Self {
         Self(val)
     }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,12 +10,13 @@ use self::adapter::{DbAdapter, DbAdapterType};
 use crate::{
     config::Config,
     errors::{self, CustomResult},
+    multitenancy::TenantId,
 };
 
 #[derive(Clone)]
 pub struct DbState<C, T: DbAdapterType> {
     pub pool: C,
-    _adapter: std::marker::PhantomData<T>,
+    _metrics: T::Metrics,
 }
 
 type Connection<'a> = PooledConnection<'a, AsyncPgConnection>;
@@ -29,9 +30,10 @@ where
     /// Panics if unable to connect to Database
     pub async fn from_config(
         config: &Config,
+        tenant_id: &TenantId,
         schema: &str,
     ) -> DbState<<Self as DbAdapter>::Pool, <Self as DbAdapter>::AdapterType> {
-        <Self as DbAdapter>::from_config(config, schema).await
+        <Self as DbAdapter>::from_config(config, tenant_id, schema).await
     }
 
     pub async fn get_conn(

--- a/src/storage/adapter.rs
+++ b/src/storage/adapter.rs
@@ -1,16 +1,23 @@
 mod cassandra;
 mod postgres;
 
-use crate::{config::Config, errors, storage::DbState};
+use crate::{config::Config, errors, multitenancy::TenantId, storage::DbState};
 
 #[derive(Clone)]
 pub struct PostgreSQL;
 pub struct Cassandra;
 
-pub trait DbAdapterType {}
+pub trait DbAdapterType {
+    type Metrics;
+}
 
-impl DbAdapterType for PostgreSQL {}
-impl DbAdapterType for Cassandra {}
+impl DbAdapterType for PostgreSQL {
+    type Metrics = postgres::PostgresPoolMetrics;
+}
+
+impl DbAdapterType for Cassandra {
+    type Metrics = cassandra::CassandraMetrics;
+}
 
 #[async_trait::async_trait]
 pub trait DbAdapter {
@@ -19,7 +26,13 @@ pub trait DbAdapter {
         Self: 'a;
     type AdapterType: DbAdapterType;
     type Pool;
-    async fn from_config(config: &Config, schema: &str) -> DbState<Self::Pool, Self::AdapterType>;
+
+    async fn from_config(
+        config: &Config,
+        tenant_id: &TenantId,
+        schema: &str,
+    ) -> DbState<Self::Pool, Self::AdapterType>;
+
     async fn get_conn<'a>(
         &'a self,
     ) -> errors::CustomResult<Self::Conn<'a>, errors::ConnectionError>;

--- a/src/storage/adapter/cassandra.rs
+++ b/src/storage/adapter/cassandra.rs
@@ -1,6 +1,12 @@
 mod dek;
 
-use crate::storage::{Config, DbState, adapter::Cassandra, errors};
+use crate::{
+    multitenancy::TenantId,
+    storage::{Config, DbState, adapter::Cassandra, errors},
+};
+
+// To be implemented. Currently, not recording any Cassandra metrics.
+pub struct CassandraMetrics;
 
 #[async_trait::async_trait]
 impl super::DbAdapter for DbState<scylla::client::caching_session::CachingSession, Cassandra> {
@@ -9,7 +15,7 @@ impl super::DbAdapter for DbState<scylla::client::caching_session::CachingSessio
     type Pool = scylla::client::caching_session::CachingSession;
 
     #[allow(clippy::expect_used)]
-    async fn from_config(config: &Config, schema: &str) -> Self {
+    async fn from_config(config: &Config, _tenant_id: &TenantId, schema: &str) -> Self {
         let session = scylla::client::session_builder::SessionBuilder::new()
             .known_nodes(&config.cassandra.known_nodes)
             .pool_size(scylla::client::PoolSize::PerHost(
@@ -21,11 +27,11 @@ impl super::DbAdapter for DbState<scylla::client::caching_session::CachingSessio
             .expect("Unable to build the cassandra Pool");
 
         Self {
-            _adapter: std::marker::PhantomData,
             pool: scylla::client::caching_session::CachingSession::from(
                 session,
                 config.cassandra.cache_size,
             ),
+            _metrics: CassandraMetrics,
         }
     }
 

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -10,7 +10,93 @@ use hyperswitch_masking::{ExposeInterface, PeekInterface};
 #[cfg(feature = "postgres_ssl")]
 use rustls::pki_types::pem::PemObject;
 
-use crate::storage::{Config, Connection, DbState, adapter::PostgreSQL, errors};
+use crate::{
+    env::metrics,
+    multitenancy::TenantId,
+    storage::{
+        Config, Connection, DbState, adapter::PostgreSQL, errors, metrics as storage_metrics,
+    },
+};
+
+pub struct PostgresPoolMetrics {
+    // The `ObservableCounter`s aren't read directly, we just need to keep them alive for metrics
+    // to be recorded.
+    _created_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
+    _closed_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
+}
+
+impl PostgresPoolMetrics {
+    pub(super) fn new(pool: Pool<AsyncPgConnection>, tenant_id: &TenantId) -> Self {
+        let db_pool = storage_metrics::DbPool::Primary;
+
+        let pool_clone = pool.clone();
+        let tenant_id_clone = tenant_id.to_owned();
+        let _created_connections = metrics::CRIPTA_METER
+            .u64_observable_counter("database.pool.created")
+            .with_description("Total database connections created")
+            .with_unit("{connection}")
+            .with_callback(move |observer| {
+                let stats = pool_clone.state().statistics;
+                let tenant_id = tenant_id_clone.clone().into_inner();
+
+                observer.observe(
+                    stats.connections_created,
+                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
+                );
+            })
+            .build();
+
+        let pool_clone = pool.clone();
+        let tenant_id_clone = tenant_id.to_owned();
+        let _closed_connections = metrics::CRIPTA_METER
+            .u64_observable_counter("database.pool.closed")
+            .with_description("Total database connections closed")
+            .with_unit("{connection}")
+            .with_callback(move |observer| {
+                let stats = pool_clone.state().statistics;
+                let tenant_id = tenant_id_clone.clone().into_inner();
+
+                observer.observe(
+                    stats.connections_closed_broken,
+                    metrics_utils::metric_attributes!(
+                        ("pool", db_pool),
+                        ("tenant_id", tenant_id.clone()),
+                        ("reason", "broken")
+                    ),
+                );
+                observer.observe(
+                    stats.connections_closed_invalid,
+                    metrics_utils::metric_attributes!(
+                        ("pool", db_pool),
+                        ("tenant_id", tenant_id.clone()),
+                        ("reason", "invalid")
+                    ),
+                );
+                observer.observe(
+                    stats.connections_closed_max_lifetime,
+                    metrics_utils::metric_attributes!(
+                        ("pool", db_pool),
+                        ("tenant_id", tenant_id.clone()),
+                        ("reason", "max_lifetime")
+                    ),
+                );
+                observer.observe(
+                    stats.connections_closed_idle_timeout,
+                    metrics_utils::metric_attributes!(
+                        ("pool", db_pool),
+                        ("tenant_id", tenant_id),
+                        ("reason", "idle_timeout")
+                    ),
+                );
+            })
+            .build();
+
+        Self {
+            _created_connections,
+            _closed_connections,
+        }
+    }
+}
 
 fn no_tls_custom_setup(
     pg_config: tokio_postgres::Config,
@@ -60,7 +146,7 @@ impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
     ///
     /// Panics if unable to connect to Database
     #[allow(clippy::expect_used)]
-    async fn from_config(config: &Config, schema: &str) -> Self {
+    async fn from_config(config: &Config, tenant_id: &TenantId, schema: &str) -> Self {
         let database = &config.database;
         let password = database.password.expose(config).await;
         let pg_config = build_pg_config(database, schema, password);
@@ -150,10 +236,9 @@ impl super::DbAdapter for DbState<Pool<AsyncPgConnection>, PostgreSQL> {
             .await
             .expect("Failed to establish pool connection");
 
-        Self {
-            _adapter: std::marker::PhantomData,
-            pool,
-        }
+        let _metrics = PostgresPoolMetrics::new(pool.clone(), tenant_id);
+
+        Self { pool, _metrics }
     }
 
     async fn get_conn<'a>(


### PR DESCRIPTION
### Description

This PR adds two `ObservableCounter`s to report the Postgres database pool metrics about cumulative number of connections created and closed. These values are obtained from [`bb8::Statistics`](https://docs.rs/bb8/0.9.1/bb8/struct.Statistics.html) as of now. Further, we are required to use `ObservableCounter`s and not regular `Counter`s, as `Counter` doesn't allow recording the cumulative value directly but only the deltas to be added. The metrics instruments are included as a struct within the `DbState` type, so we construct one set of counters for each tenant. Additionally, as a result of using `ObservableCounter`s now, the counter values are recorded at the time of export, and the metrics are expected to be mostly up-to-date.

This PR also introduces a no-op `CassandraMetrics` struct which intentionally does not do anything. We don't have any Cassandra metrics today, we can choose to extend that struct with fields when we instrument Cassandra operations on a later date.

### Testing

Ran locally with `max_lifetime_secs` set to 30 seconds, and `idle_timeout_secs` to 10 seconds, I'm able to see metrics for connections created and closed being recorded:

```shell
$ curl http://localhost:6128/metrics | rg 'database_pool_(created|closed)'
# HELP database_pool_closed_total Total database connections closed
# TYPE database_pool_closed_total counter
database_pool_closed_total{pool="primary",reason="broken",tenant_id="global",otel_scope_name="encryption_service"} 0
database_pool_closed_total{pool="primary",reason="broken",tenant_id="public",otel_scope_name="encryption_service"} 0
database_pool_closed_total{pool="primary",reason="idle_timeout",tenant_id="global",otel_scope_name="encryption_service"} 8
database_pool_closed_total{pool="primary",reason="idle_timeout",tenant_id="public",otel_scope_name="encryption_service"} 8
database_pool_closed_total{pool="primary",reason="invalid",tenant_id="global",otel_scope_name="encryption_service"} 0
database_pool_closed_total{pool="primary",reason="invalid",tenant_id="public",otel_scope_name="encryption_service"} 0
database_pool_closed_total{pool="primary",reason="max_lifetime",tenant_id="global",otel_scope_name="encryption_service"} 0
database_pool_closed_total{pool="primary",reason="max_lifetime",tenant_id="public",otel_scope_name="encryption_service"} 0
# HELP database_pool_created_total Total database connections created
# TYPE database_pool_created_total counter
database_pool_created_total{pool="primary",tenant_id="global",otel_scope_name="encryption_service"} 10
database_pool_created_total{pool="primary",tenant_id="public",otel_scope_name="encryption_service"} 10
```