### PR TITLE
refactor(metrics): unify all pull-based metrics as observable instruments and eliminate background collector

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -69,14 +69,10 @@ mode = "otlp" # Options: "disabled" (default), "otlp", "prometheus"
 endpoint = "http://127.0.0.1:4317"                 # OTLP gRPC endpoint
 endpoint_timeout_secs = 10                         # Connection timeout in seconds
 metrics_export_interval_secs = 15                  # Export interval in seconds
-background_metrics_collection_interval_secs = 15   # Interval (in seconds) for the background metrics collector.
-                                                   # Collects database pool state and cache entry count gauges.
 
 # When mode is "prometheus", configure the Prometheus HTTP server:
 # host = "127.0.0.1"                                # IP address the Prometheus HTTP server listens on
 # port = 6128                                       # Port the Prometheus HTTP server listens on
-# background_metrics_collection_interval_secs = 15  # Interval (in seconds) for the background metrics collector.
-                                                    # Collects database pool state and cache entry count gauges.
 
 # Secrets and encryption configuration
 # The service supports three mutually exclusive key management strategies chosen at compile time:

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,7 +70,7 @@ impl SessionState {
         let num_threads = config.pool_config.pool;
 
         Self {
-            caches: Caches::from_config(&config.cache),
+            caches: Caches::from_config(&config.cache, tenant_id),
             keymanager_client: secrets.create_keymanager_client().await,
             db_pool,
             thread_pool: ThreadPoolBuilder::new()

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -40,8 +40,6 @@ async fn main() {
 
     logger::info!(?config, "Application starting");
 
-    let background_metrics_interval = config.metrics.background_metrics_collection_interval_secs();
-
     #[cfg(any(feature = "mtls", feature = "postgres_ssl"))]
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
@@ -106,10 +104,6 @@ async fn main() {
             state.clone(),
         )
         .expect("Failed to start Prometheus metrics server");
-    }
-
-    if guards.metrics_handle().is_enabled() {
-        observability::spawn_bg_metrics_collector(&state, background_metrics_interval);
     }
 
     #[cfg(feature = "mtls")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,8 +222,6 @@ pub enum MetricsConfig {
         endpoint_timeout_secs: u64,
         #[serde(default = "default_export_interval")]
         metrics_export_interval_secs: u64,
-        #[serde(default = "default_bg_metrics_interval")]
-        background_metrics_collection_interval_secs: std::num::NonZeroU64,
     },
 
     Prometheus {
@@ -231,8 +229,6 @@ pub enum MetricsConfig {
         host: String,
         #[serde(default = "default_prometheus_port")]
         port: u16,
-        #[serde(default = "default_bg_metrics_interval")]
-        background_metrics_collection_interval_secs: std::num::NonZeroU64,
     },
 }
 
@@ -250,11 +246,6 @@ fn default_prometheus_host() -> String {
 
 const fn default_prometheus_port() -> u16 {
     6128
-}
-
-fn default_bg_metrics_interval() -> std::num::NonZeroU64 {
-    #[allow(clippy::expect_used)]
-    std::num::NonZeroU64::new(15).expect("15 is non-zero")
 }
 
 impl MetricsConfig {
@@ -290,22 +281,6 @@ impl MetricsConfig {
                 }
                 Ok(())
             }
-        }
-    }
-
-    pub fn background_metrics_collection_interval_secs(&self) -> u64 {
-        match self {
-            // We shouldn't be reaching this arm preferably,
-            // we shouldn't be launching the metrics collection task if metrics are disabled.
-            Self::Disabled => default_bg_metrics_interval().get(),
-            Self::Otlp {
-                background_metrics_collection_interval_secs,
-                ..
-            }
-            | Self::Prometheus {
-                background_metrics_collection_interval_secs,
-                ..
-            } => background_metrics_collection_interval_secs.get(),
         }
     }
 }

--- a/src/env/metrics.rs
+++ b/src/env/metrics.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use axum::Router;
 use metrics_utils::{
-    counter_metric, f64_histogram_buckets, gauge_metric, global_meter, histogram_metric_f64,
+    counter_metric, f64_histogram_buckets, global_meter, histogram_metric_f64,
     up_down_counter_metric,
 };
 
@@ -159,35 +159,6 @@ pub fn spawn_prometheus_metrics_server(
     Ok(())
 }
 
-pub fn spawn_bg_metrics_collector(
-    global_state: &Arc<AppState>,
-    background_metrics_collection_interval_secs: u64,
-) {
-    let interval = Duration::from_secs(background_metrics_collection_interval_secs);
-
-    let global_state = global_state.clone();
-
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(interval);
-
-        // Skip the first tick, which resolves immediately.
-        // We want to start metrics collection after the first interval has elapsed.
-        interval.tick().await;
-
-        loop {
-            interval.tick().await;
-
-            for (tenant_id, tenant_state) in global_state.tenant_states.iter() {
-                // Collect cache entry count gauges
-                tenant_state
-                    .caches
-                    .record_entry_count_metric(tenant_id.as_str())
-                    .await;
-            }
-        }
-    });
-}
-
 global_meter!(pub(crate) CRIPTA_METER, "encryption_service");
 
 // HTTP server
@@ -251,12 +222,6 @@ counter_metric!(
     name: "cache.removal.count",
     description: "Number of cache removal events",
     unit: "{event}",
-);
-gauge_metric!(
-    pub(crate) CACHE_ENTRY_COUNT, CRIPTA_METER,
-    name: "cache.entry.count",
-    description: "Current number of cache entries",
-    unit: "{entry}",
 );
 
 // Key manager

--- a/src/env/metrics.rs
+++ b/src/env/metrics.rs
@@ -178,12 +178,6 @@ pub fn spawn_bg_metrics_collector(
             interval.tick().await;
 
             for (tenant_id, tenant_state) in global_state.tenant_states.iter() {
-                #[cfg(not(feature = "cassandra"))]
-                // Collect DB pool state gauges
-                tenant_state
-                    .db_pool()
-                    .collect_db_pool_state(tenant_id.as_str());
-
                 // Collect cache entry count gauges
                 tenant_state
                     .caches
@@ -237,24 +231,6 @@ histogram_metric_f64!(
     description: "Duration of database connection acquisition attempts",
     unit: "s",
     buckets: f64_histogram_buckets().to_vec(),
-);
-gauge_metric!(
-    pub(crate) DATABASE_POOL_SIZE, CRIPTA_METER,
-    name: "database.pool.size",
-    description: "Total number of connections in the database pool",
-    unit: "{connection}",
-);
-gauge_metric!(
-    pub(crate) DATABASE_POOL_AVAILABLE, CRIPTA_METER,
-    name: "database.pool.available",
-    description: "Number of available connections in the database pool",
-    unit: "{connection}",
-);
-gauge_metric!(
-    pub(crate) DATABASE_POOL_WAITING, CRIPTA_METER,
-    name: "database.pool.waiting",
-    description: "Number of callers waiting for a database connection",
-    unit: "{connection}",
 );
 
 // Cache

--- a/src/env/observability.rs
+++ b/src/env/observability.rs
@@ -6,10 +6,7 @@ use super::{
 };
 pub use super::{
     logger::{LogConfig, LogLevel},
-    metrics::{
-        HttpRequestMetricsLayer, MetricsHandle, spawn_bg_metrics_collector,
-        spawn_prometheus_metrics_server,
-    },
+    metrics::{HttpRequestMetricsLayer, MetricsHandle, spawn_prometheus_metrics_server},
 };
 use crate::config::Config;
 

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -19,10 +19,13 @@ use crate::{
 };
 
 pub struct PostgresPoolMetrics {
-    // The `ObservableCounter`s aren't read directly, we just need to keep them alive for metrics
+    // The observable instruments aren't read directly, we just need to keep them alive for metrics
     // to be recorded.
     _created_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
     _closed_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
+    _pool_size: metrics_utils::opentelemetry::ObservableGauge<u64>,
+    _pool_available: metrics_utils::opentelemetry::ObservableGauge<u64>,
+    _pool_waiting: metrics_utils::opentelemetry::ObservableGauge<u64>,
 }
 
 impl PostgresPoolMetrics {
@@ -91,9 +94,63 @@ impl PostgresPoolMetrics {
             })
             .build();
 
+        let pool_clone = pool.clone();
+        let tenant_id_clone = tenant_id.to_owned();
+        let _pool_size = metrics::CRIPTA_METER
+            .u64_observable_gauge("database.pool.size")
+            .with_description("Total number of connections in the database pool")
+            .with_unit("{connection}")
+            .with_callback(move |observer| {
+                let state = pool_clone.state();
+                let tenant_id = tenant_id_clone.clone().into_inner();
+
+                observer.observe(
+                    u64::from(state.connections),
+                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
+                );
+            })
+            .build();
+
+        let pool_clone = pool.clone();
+        let tenant_id_clone = tenant_id.to_owned();
+        let _pool_available = metrics::CRIPTA_METER
+            .u64_observable_gauge("database.pool.available")
+            .with_description("Number of available connections in the database pool")
+            .with_unit("{connection}")
+            .with_callback(move |observer| {
+                let state = pool_clone.state();
+                let tenant_id = tenant_id_clone.clone().into_inner();
+
+                observer.observe(
+                    u64::from(state.idle_connections),
+                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
+                );
+            })
+            .build();
+
+        let pool_clone = pool.clone();
+        let tenant_id_clone = tenant_id.to_owned();
+        let _pool_waiting = metrics::CRIPTA_METER
+            .u64_observable_gauge("database.pool.waiting")
+            .with_description("Number of callers waiting for a database connection")
+            .with_unit("{connection}")
+            .with_callback(move |observer| {
+                let state = pool_clone.state();
+                let tenant_id = tenant_id_clone.clone().into_inner();
+
+                observer.observe(
+                    state.statistics.pending_gets(),
+                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
+                );
+            })
+            .build();
+
         Self {
             _created_connections,
             _closed_connections,
+            _pool_size,
+            _pool_available,
+            _pool_waiting,
         }
     }
 }

--- a/src/storage/adapter/postgres.rs
+++ b/src/storage/adapter/postgres.rs
@@ -21,137 +21,130 @@ use crate::{
 pub struct PostgresPoolMetrics {
     // The observable instruments aren't read directly, we just need to keep them alive for metrics
     // to be recorded.
-    _created_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
-    _closed_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
     _pool_size: metrics_utils::opentelemetry::ObservableGauge<u64>,
     _pool_available: metrics_utils::opentelemetry::ObservableGauge<u64>,
     _pool_waiting: metrics_utils::opentelemetry::ObservableGauge<u64>,
+    _created_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
+    _closed_connections: metrics_utils::opentelemetry::ObservableCounter<u64>,
 }
 
 impl PostgresPoolMetrics {
     pub(super) fn new(pool: Pool<AsyncPgConnection>, tenant_id: &TenantId) -> Self {
         let db_pool = storage_metrics::DbPool::Primary;
 
-        let pool_clone = pool.clone();
-        let tenant_id_clone = tenant_id.to_owned();
-        let _created_connections = metrics::CRIPTA_METER
-            .u64_observable_counter("database.pool.created")
-            .with_description("Total database connections created")
-            .with_unit("{connection}")
-            .with_callback(move |observer| {
-                let stats = pool_clone.state().statistics;
-                let tenant_id = tenant_id_clone.clone().into_inner();
+        let _pool_size = Self::build_pool_gauge(
+            "database.pool.size",
+            "Total number of connections in the database pool",
+            "{connection}",
+            db_pool,
+            pool.clone(),
+            tenant_id.clone(),
+            |pool| u64::from(pool.state().connections),
+        );
 
-                observer.observe(
-                    stats.connections_created,
-                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
-                );
-            })
-            .build();
+        let _pool_available = Self::build_pool_gauge(
+            "database.pool.available",
+            "Number of available connections in the database pool",
+            "{connection}",
+            db_pool,
+            pool.clone(),
+            tenant_id.clone(),
+            |pool| u64::from(pool.state().idle_connections),
+        );
 
-        let pool_clone = pool.clone();
-        let tenant_id_clone = tenant_id.to_owned();
-        let _closed_connections = metrics::CRIPTA_METER
-            .u64_observable_counter("database.pool.closed")
-            .with_description("Total database connections closed")
-            .with_unit("{connection}")
-            .with_callback(move |observer| {
-                let stats = pool_clone.state().statistics;
-                let tenant_id = tenant_id_clone.clone().into_inner();
+        let _pool_waiting = Self::build_pool_gauge(
+            "database.pool.waiting",
+            "Number of callers waiting for a database connection",
+            "{connection}",
+            db_pool,
+            pool.clone(),
+            tenant_id.clone(),
+            |pool| pool.state().statistics.pending_gets(),
+        );
 
-                observer.observe(
-                    stats.connections_closed_broken,
-                    metrics_utils::metric_attributes!(
-                        ("pool", db_pool),
-                        ("tenant_id", tenant_id.clone()),
-                        ("reason", "broken")
-                    ),
-                );
-                observer.observe(
-                    stats.connections_closed_invalid,
-                    metrics_utils::metric_attributes!(
-                        ("pool", db_pool),
-                        ("tenant_id", tenant_id.clone()),
-                        ("reason", "invalid")
-                    ),
-                );
-                observer.observe(
-                    stats.connections_closed_max_lifetime,
-                    metrics_utils::metric_attributes!(
-                        ("pool", db_pool),
-                        ("tenant_id", tenant_id.clone()),
-                        ("reason", "max_lifetime")
-                    ),
-                );
-                observer.observe(
-                    stats.connections_closed_idle_timeout,
-                    metrics_utils::metric_attributes!(
-                        ("pool", db_pool),
-                        ("tenant_id", tenant_id),
-                        ("reason", "idle_timeout")
-                    ),
-                );
-            })
-            .build();
+        let _created_connections = {
+            let pool_clone = pool.clone();
+            let tenant_id_clone = tenant_id.to_owned();
+            metrics::CRIPTA_METER
+                .u64_observable_counter("database.pool.created")
+                .with_description("Total database connections created")
+                .with_unit("{connection}")
+                .with_callback(move |observer| {
+                    let stats = pool_clone.state().statistics;
+                    let tenant_id = tenant_id_clone.clone().into_inner();
 
-        let pool_clone = pool.clone();
-        let tenant_id_clone = tenant_id.to_owned();
-        let _pool_size = metrics::CRIPTA_METER
-            .u64_observable_gauge("database.pool.size")
-            .with_description("Total number of connections in the database pool")
-            .with_unit("{connection}")
-            .with_callback(move |observer| {
-                let state = pool_clone.state();
-                let tenant_id = tenant_id_clone.clone().into_inner();
+                    observer.observe(
+                        stats.connections_created,
+                        metrics_utils::metric_attributes!(
+                            ("pool", db_pool),
+                            ("tenant_id", tenant_id)
+                        ),
+                    );
+                })
+                .build()
+        };
 
-                observer.observe(
-                    u64::from(state.connections),
-                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
-                );
-            })
-            .build();
+        let _closed_connections = {
+            let pool_clone = pool;
+            let tenant_id_clone = tenant_id.to_owned();
+            metrics::CRIPTA_METER
+                .u64_observable_counter("database.pool.closed")
+                .with_description("Total database connections closed")
+                .with_unit("{connection}")
+                .with_callback(move |observer| {
+                    let stats = pool_clone.state().statistics;
+                    let tenant_id = tenant_id_clone.clone().into_inner();
 
-        let pool_clone = pool.clone();
-        let tenant_id_clone = tenant_id.to_owned();
-        let _pool_available = metrics::CRIPTA_METER
-            .u64_observable_gauge("database.pool.available")
-            .with_description("Number of available connections in the database pool")
-            .with_unit("{connection}")
-            .with_callback(move |observer| {
-                let state = pool_clone.state();
-                let tenant_id = tenant_id_clone.clone().into_inner();
-
-                observer.observe(
-                    u64::from(state.idle_connections),
-                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
-                );
-            })
-            .build();
-
-        let pool_clone = pool.clone();
-        let tenant_id_clone = tenant_id.to_owned();
-        let _pool_waiting = metrics::CRIPTA_METER
-            .u64_observable_gauge("database.pool.waiting")
-            .with_description("Number of callers waiting for a database connection")
-            .with_unit("{connection}")
-            .with_callback(move |observer| {
-                let state = pool_clone.state();
-                let tenant_id = tenant_id_clone.clone().into_inner();
-
-                observer.observe(
-                    state.statistics.pending_gets(),
-                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
-                );
-            })
-            .build();
+                    for (value, reason) in [
+                        (stats.connections_closed_broken, "broken"),
+                        (stats.connections_closed_invalid, "invalid"),
+                        (stats.connections_closed_max_lifetime, "max_lifetime"),
+                        (stats.connections_closed_idle_timeout, "idle_timeout"),
+                    ] {
+                        observer.observe(
+                            value,
+                            metrics_utils::metric_attributes!(
+                                ("pool", db_pool),
+                                ("tenant_id", tenant_id.clone()),
+                                ("reason", reason)
+                            ),
+                        );
+                    }
+                })
+                .build()
+        };
 
         Self {
-            _created_connections,
-            _closed_connections,
             _pool_size,
             _pool_available,
             _pool_waiting,
+            _created_connections,
+            _closed_connections,
         }
+    }
+
+    fn build_pool_gauge(
+        name: &'static str,
+        description: &'static str,
+        unit: &'static str,
+        db_pool: storage_metrics::DbPool,
+        pool: Pool<AsyncPgConnection>,
+        tenant_id: TenantId,
+        read: impl Fn(&Pool<AsyncPgConnection>) -> u64 + Send + Sync + 'static,
+    ) -> metrics_utils::opentelemetry::ObservableGauge<u64> {
+        metrics::CRIPTA_METER
+            .u64_observable_gauge(name)
+            .with_description(description)
+            .with_unit(unit)
+            .with_callback(move |observer| {
+                let tenant_id = tenant_id.clone().into_inner();
+
+                observer.observe(
+                    read(&pool),
+                    metrics_utils::metric_attributes!(("pool", db_pool), ("tenant_id", tenant_id)),
+                );
+            })
+            .build()
     }
 }
 

--- a/src/storage/cache.rs
+++ b/src/storage/cache.rs
@@ -4,6 +4,7 @@ use crate::{
     config::CacheConfig,
     env::metrics,
     errors,
+    multitenancy::TenantId,
     types::{Key, key::Version},
 };
 
@@ -24,13 +25,22 @@ where
 {
     inner: MokaCache<CacheKey, V>,
     name: &'static str,
+    // The observable instruments aren't read directly, we just need to keep them alive for metrics
+    // to be recorded.
+    _entry_count: metrics_utils::opentelemetry::ObservableGauge<u64>,
 }
 
 impl<V> Cache<V>
 where
     V: Send + Sync + Clone + 'static,
 {
-    fn new(name: &'static str, time_to_live: u64, time_to_idle: u64, max_capacity: u64) -> Self {
+    fn new(
+        name: &'static str,
+        time_to_live: u64,
+        time_to_idle: u64,
+        max_capacity: u64,
+        tenant_id: &TenantId,
+    ) -> Self {
         let cache_builder = MokaCache::builder()
             .time_to_live(std::time::Duration::from_secs(time_to_live))
             .time_to_idle(std::time::Duration::from_secs(time_to_idle))
@@ -41,9 +51,33 @@ where
                 }
             });
 
+        let inner = cache_builder.build();
+
+        let _entry_count = {
+            let inner_clone = inner.clone();
+            let tenant_id_clone = tenant_id.to_owned();
+            metrics::CRIPTA_METER
+                .u64_observable_gauge("cache.entry.count")
+                .with_description("Current number of cache entries")
+                .with_unit("{entry}")
+                .with_callback(move |observer| {
+                    let tenant_id = tenant_id_clone.clone().into_inner();
+
+                    observer.observe(
+                        inner_clone.entry_count(),
+                        metrics_utils::metric_attributes!(
+                            ("cache", name),
+                            ("tenant_id", tenant_id)
+                        ),
+                    );
+                })
+                .build()
+        };
+
         Self {
-            inner: cache_builder.build(),
+            inner,
             name,
+            _entry_count,
         }
     }
 
@@ -65,18 +99,6 @@ where
 
         value
     }
-
-    async fn record_entry_count_metric(&self, tenant_id: &str) {
-        self.inner.run_pending_tasks().await;
-
-        metrics::CACHE_ENTRY_COUNT.record(
-            self.inner.entry_count(),
-            metrics_utils::metric_attributes!(
-                ("cache", self.name),
-                ("tenant_id", tenant_id.to_owned()),
-            ),
-        );
-    }
 }
 
 pub struct Caches {
@@ -85,26 +107,23 @@ pub struct Caches {
 }
 
 impl Caches {
-    pub fn from_config(config: &CacheConfig) -> Self {
+    pub fn from_config(config: &CacheConfig, tenant_id: &TenantId) -> Self {
         Self {
             version: Cache::new(
                 "version",
                 config.time_to_live_secs,
                 config.time_to_idle_secs,
                 config.max_capacity.get(),
+                tenant_id,
             ),
             key: Cache::new(
                 "key",
                 config.time_to_live_secs,
                 config.time_to_idle_secs,
                 config.max_capacity.get(),
+                tenant_id,
             ),
         }
-    }
-
-    pub async fn record_entry_count_metric(&self, tenant_id: &str) {
-        self.version.record_entry_count_metric(tenant_id).await;
-        self.key.record_entry_count_metric(tenant_id).await;
     }
 }
 

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -120,22 +120,3 @@ where
 
     result
 }
-
-#[cfg(not(feature = "cassandra"))]
-impl
-    crate::storage::DbState<
-        diesel_async::pooled_connection::bb8::Pool<diesel_async::AsyncPgConnection>,
-        crate::storage::adapter::PostgreSQL,
-    >
-{
-    pub(crate) fn collect_db_pool_state(&self, tenant_id: &str) {
-        let state = self.pool.state();
-        let pool = DbPool::Primary;
-        let attrs =
-            metrics_utils::metric_attributes!(("pool", pool), ("tenant_id", tenant_id.to_owned()));
-
-        metrics::DATABASE_POOL_SIZE.record(u64::from(state.connections), attrs);
-        metrics::DATABASE_POOL_AVAILABLE.record(u64::from(state.idle_connections), attrs);
-        metrics::DATABASE_POOL_WAITING.record(state.statistics.pending_gets(), attrs);
-    }
-}


### PR DESCRIPTION
### Description

Following #78, this PR moves all pull-based metrics that were recorded in the background metrics collector task to observable gauges. The metric names haven't changed in this migration, so this should not be a breaking change. Further, this PR also removes the background metrics collector task (and the relevant config used to configure the interval), as it is now obsolete. 

This PR includes the following changes:
- Migrates `database.pool.size`, `database.pool.available`, and `database.pool.waiting` to `ObservableGauge`s placed in `PostgresPoolMetrics`.
- Refactors `PostgresPoolMetrics::new()` to reduce some duplicate code.
- Migrates `cache.entry.count` to an `ObservableGauge` stored in the `Cache` instance itself.
  - One thing to note is that we no longer call `run_pending_tasks()` since it's an async method and the callback for the `ObservableGauge` is expected to be a sync function. As a result, the cache entry count may not be exact but accurate enough as `moka`'s housekeeper runs automatically every 300ms / 64 operations.

### Testing

Ran locally and tested with the Postman collection, I see the database pool metrics and cache entry count still being recorded:

```shell
$ curl http://localhost:6128/metrics | rg 'database_pool_(size|waiting|available)|cache_entry_count'
# HELP cache_entry_count Current number of cache entries
# TYPE cache_entry_count gauge
cache_entry_count{cache="key",tenant_id="global",otel_scope_name="encryption_service"} 0
cache_entry_count{cache="key",tenant_id="public",otel_scope_name="encryption_service"} 10
cache_entry_count{cache="version",tenant_id="global",otel_scope_name="encryption_service"} 0
cache_entry_count{cache="version",tenant_id="public",otel_scope_name="encryption_service"} 8
# HELP database_pool_available Number of available connections in the database pool
# TYPE database_pool_available gauge
database_pool_available{pool="primary",tenant_id="global",otel_scope_name="encryption_service"} 2
database_pool_available{pool="primary",tenant_id="public",otel_scope_name="encryption_service"} 4
# HELP database_pool_size Total number of connections in the database pool
# TYPE database_pool_size gauge
database_pool_size{pool="primary",tenant_id="global",otel_scope_name="encryption_service"} 2
database_pool_size{pool="primary",tenant_id="public",otel_scope_name="encryption_service"} 4
# HELP database_pool_waiting Number of callers waiting for a database connection
# TYPE database_pool_waiting gauge
database_pool_waiting{pool="primary",tenant_id="global",otel_scope_name="encryption_service"} 0
database_pool_waiting{pool="primary",tenant_id="public",otel_scope_name="encryption_service"} 0
```