### PR TITLE
feat: configure server with tcp_nodelay

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -14,15 +14,6 @@ port = 5000        # Port the HTTP server listens on. Use a port that does not c
 # timer adds ~40ms. Set false only to deliberately reproduce that behaviour.
 set_tcp_nodelay = true
 
-# Offers HTTP/2 via ALPN during the TLS handshake.
-# (optional, default: true; requires the `mtls` feature — plaintext is HTTP/1.1)
-#
-# HTTP/2 multiplexes concurrent requests from one client onto a single
-# connection, keeping TLS handshake cost flat as concurrency grows. Setting this
-# to false forces clients onto HTTP/1.1, giving each concurrent request its own
-# connection.
-enable_http2 = true
-
 # Database configuration
 [database]
 host = "localhost"                   # Database hostname or IP address

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -6,6 +6,23 @@
 host = "127.0.0.1" # IP address the HTTP server listens on
 port = 5000        # Port the HTTP server listens on. Use a port that does not conflict with other services.
 
+# Sets TCP_NODELAY on accepted sockets, disabling Nagle's algorithm.
+# (optional, default: true — the correct setting for a request/response service)
+#
+# With Nagle active, two responses written back-to-back on one connection stall:
+# the second waits on the first's acknowledgement, and the peer's delayed-ACK
+# timer adds ~40ms. Set false only to deliberately reproduce that behaviour.
+set_tcp_nodelay = true
+
+# Offers HTTP/2 via ALPN during the TLS handshake.
+# (optional, default: true; requires the `mtls` feature — plaintext is HTTP/1.1)
+#
+# HTTP/2 multiplexes concurrent requests from one client onto a single
+# connection, keeping TLS handshake cost flat as concurrency grows. Setting this
+# to false forces clients onto HTTP/1.1, giving each concurrent request its own
+# connection.
+enable_http2 = true
+
 # Database configuration
 [database]
 host = "localhost"                   # Database hostname or IP address

--- a/config/development.toml
+++ b/config/development.toml
@@ -10,7 +10,6 @@ pool = 2
 host = "127.0.0.1"
 port = 5000
 set_tcp_nodelay = true
-enable_http2 = true
 
 [database]
 user = "db_user"

--- a/config/development.toml
+++ b/config/development.toml
@@ -9,6 +9,10 @@ pool = 2
 [server]
 host = "127.0.0.1"
 port = 5000
+# Disable Nagle's algorithm on accepted sockets. Leave true.
+set_tcp_nodelay = true
+# Offer HTTP/2 via ALPN (mtls builds only; plaintext is always HTTP/1.1).
+enable_http2 = true
 
 [database]
 user = "db_user"

--- a/config/development.toml
+++ b/config/development.toml
@@ -9,9 +9,7 @@ pool = 2
 [server]
 host = "127.0.0.1"
 port = 5000
-# Disable Nagle's algorithm on accepted sockets. Leave true.
 set_tcp_nodelay = true
-# Offer HTTP/2 via ALPN (mtls builds only; plaintext is always HTTP/1.1).
 enable_http2 = true
 
 [database]

--- a/src/app/tls.rs
+++ b/src/app/tls.rs
@@ -11,7 +11,6 @@ use crate::config::Config;
 
 pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
     let certs = config.certs.clone();
-    let server = &config.server;
 
     let cert = CertificateDer::pem_slice_iter(certs.tls_cert.expose(config).await.peek().as_ref())
         .map(|it| it.map_err(io::Error::other))
@@ -38,13 +37,7 @@ pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
         .with_single_cert(cert, priv_key)
         .map_err(io::Error::other)?;
 
-    // ALPN decides whether concurrent requests from one client share a single
-    // multiplexed connection (h2) or take one connection each (http/1.1).
-    config.alpn_protocols = if server.enable_http2 {
-        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
-    } else {
-        vec![b"http/1.1".to_vec()]
-    };
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
     Ok(config)
 }

--- a/src/app/tls.rs
+++ b/src/app/tls.rs
@@ -11,6 +11,7 @@ use crate::config::Config;
 
 pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
     let certs = config.certs.clone();
+    let server = &config.server;
 
     let cert = CertificateDer::pem_slice_iter(certs.tls_cert.expose(config).await.peek().as_ref())
         .map(|it| it.map_err(io::Error::other))
@@ -37,7 +38,13 @@ pub async fn from_config(config: &Config) -> io::Result<ServerConfig> {
         .with_single_cert(cert, priv_key)
         .map_err(io::Error::other)?;
 
-    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    // ALPN decides whether concurrent requests from one client share a single
+    // multiplexed connection (h2) or take one connection each (http/1.1).
+    config.alpn_protocols = if server.enable_http2 {
+        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+    } else {
+        vec![b"http/1.1".to_vec()]
+    };
 
     Ok(config)
 }

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -121,13 +121,10 @@ async fn main() {
             .await
             .unwrap_or_else(|err| panic!("unable to read the certificates. got err:{err:?}"));
 
-        // `NoDelayAcceptor` disables Nagle's algorithm on accepted sockets. Without it,
-        // axum-server's `DefaultAcceptor` leaves Nagle enabled: when two responses are
-        // written back-to-back on one multiplexed HTTP/2 connection, the second is held
-        // until the first is acknowledged, and the peer's delayed-ACK timer adds ~40ms.
         let tls_config = RustlsConfig::from_config(Arc::new(tls));
 
         if set_tcp_nodelay {
+            // NoDelayAcceptor disables Nagle's algorithm on accepted sockets.
             axum_server::bind(host)
                 .acceptor(RustlsAcceptor::new(tls_config).acceptor(NoDelayAcceptor::new()))
                 .serve(app.into_make_service())
@@ -144,8 +141,8 @@ async fn main() {
 
     #[cfg(not(feature = "mtls"))]
     {
-        // See the mtls branch above: Nagle must be disabled on accepted sockets.
         if set_tcp_nodelay {
+            // NoDelayAcceptor disables Nagle's algorithm on accepted sockets.
             axum_server::bind(host)
                 .acceptor(axum_server::accept::NoDelayAcceptor::new())
                 .serve(app.into_make_service())

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -38,6 +38,8 @@ async fn main() {
         .parse()
         .expect("Unable to parse host");
 
+    let set_tcp_nodelay = config.server.set_tcp_nodelay;
+
     logger::info!(?config, "Application starting");
 
     #[cfg(any(feature = "mtls", feature = "postgres_ssl"))]
@@ -123,23 +125,37 @@ async fn main() {
         // axum-server's `DefaultAcceptor` leaves Nagle enabled: when two responses are
         // written back-to-back on one multiplexed HTTP/2 connection, the second is held
         // until the first is acknowledged, and the peer's delayed-ACK timer adds ~40ms.
-        let acceptor = RustlsAcceptor::new(RustlsConfig::from_config(Arc::new(tls)))
-            .acceptor(NoDelayAcceptor::new());
+        let tls_config = RustlsConfig::from_config(Arc::new(tls));
 
-        axum_server::bind(host)
-            .acceptor(acceptor)
-            .serve(app.into_make_service())
-            .await
-            .expect("unable to start the server")
+        if set_tcp_nodelay {
+            axum_server::bind(host)
+                .acceptor(RustlsAcceptor::new(tls_config).acceptor(NoDelayAcceptor::new()))
+                .serve(app.into_make_service())
+                .await
+                .expect("unable to start the server")
+        } else {
+            axum_server::bind(host)
+                .acceptor(RustlsAcceptor::new(tls_config))
+                .serve(app.into_make_service())
+                .await
+                .expect("unable to start the server")
+        }
     }
 
     #[cfg(not(feature = "mtls"))]
     {
         // See the mtls branch above: Nagle must be disabled on accepted sockets.
-        axum_server::bind(host)
-            .acceptor(axum_server::accept::NoDelayAcceptor::new())
-            .serve(app.into_make_service())
-            .await
-            .expect("unable to start the server")
+        if set_tcp_nodelay {
+            axum_server::bind(host)
+                .acceptor(axum_server::accept::NoDelayAcceptor::new())
+                .serve(app.into_make_service())
+                .await
+                .expect("unable to start the server")
+        } else {
+            axum_server::bind(host)
+                .serve(app.into_make_service())
+                .await
+                .expect("unable to start the server")
+        }
     }
 }

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -108,7 +108,10 @@ async fn main() {
 
     #[cfg(feature = "mtls")]
     {
-        use axum_server::tls_rustls::RustlsConfig;
+        use axum_server::{
+            accept::NoDelayAcceptor,
+            tls_rustls::{RustlsAcceptor, RustlsConfig},
+        };
         use cripta::app::tls;
 
         #[expect(clippy::panic)]
@@ -116,7 +119,15 @@ async fn main() {
             .await
             .unwrap_or_else(|err| panic!("unable to read the certificates. got err:{err:?}"));
 
-        axum_server::bind_rustls(host, RustlsConfig::from_config(Arc::new(tls)))
+        // `NoDelayAcceptor` disables Nagle's algorithm on accepted sockets. Without it,
+        // axum-server's `DefaultAcceptor` leaves Nagle enabled: when two responses are
+        // written back-to-back on one multiplexed HTTP/2 connection, the second is held
+        // until the first is acknowledged, and the peer's delayed-ACK timer adds ~40ms.
+        let acceptor = RustlsAcceptor::new(RustlsConfig::from_config(Arc::new(tls)))
+            .acceptor(NoDelayAcceptor::new());
+
+        axum_server::bind(host)
+            .acceptor(acceptor)
             .serve(app.into_make_service())
             .await
             .expect("unable to start the server")
@@ -124,7 +135,9 @@ async fn main() {
 
     #[cfg(not(feature = "mtls"))]
     {
+        // See the mtls branch above: Nagle must be disabled on accepted sockets.
         axum_server::bind(host)
+            .acceptor(axum_server::accept::NoDelayAcceptor::new())
             .serve(app.into_make_service())
             .await
             .expect("unable to start the server")

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,15 +210,9 @@ pub struct Server {
     pub host: String,
     #[serde(default = "default_tcp_nodelay")]
     pub set_tcp_nodelay: bool,
-    #[serde(default = "default_http2")]
-    pub enable_http2: bool,
 }
 
 const fn default_tcp_nodelay() -> bool {
-    true
-}
-
-const fn default_http2() -> bool {
     true
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,31 +209,23 @@ pub struct Server {
     pub port: u16,
     pub host: String,
 
-    /// Sets `TCP_NODELAY` on accepted sockets, disabling Nagle's algorithm.
-    /// Defaults to `true`, which is the correct setting for a request/response
-    /// service and matches what nginx, Envoy and gRPC do.
-    ///
-    /// With Nagle active, two responses written back-to-back on one connection
-    /// stall: the second is held until the first is acknowledged, and the
-    /// peer's delayed-ACK timer adds ~40ms. Only set this to `false` to
-    /// deliberately reproduce that behaviour.
-    #[serde(default = "default_true")]
+    /// Disables Nagle's algorithm on accepted sockets. Leave enabled: with Nagle
+    /// active, back-to-back responses on one connection stall on the peer's
+    /// delayed-ACK timer (~40ms).
+    #[serde(default = "default_tcp_nodelay")]
     pub set_tcp_nodelay: bool,
 
-    /// Offers HTTP/2 via ALPN during the TLS handshake. Defaults to `true`.
-    ///
-    /// Only meaningful with the `mtls` feature: ALPN is a TLS extension, so a
-    /// plaintext listener speaks HTTP/1.1 regardless of this setting.
-    ///
-    /// With HTTP/2, concurrent requests from one client are multiplexed onto a
-    /// single connection, which keeps TLS handshake cost flat as concurrency
-    /// grows. Setting this to `false` forces clients onto HTTP/1.1, giving each
-    /// concurrent request its own connection.
-    #[serde(default = "default_true")]
+    /// Offers HTTP/2 via ALPN. Only applies with the `mtls` feature, since ALPN
+    /// requires TLS; a plaintext listener is HTTP/1.1 either way.
+    #[serde(default = "default_http2")]
     pub enable_http2: bool,
 }
 
-fn default_true() -> bool {
+const fn default_tcp_nodelay() -> bool {
+    true
+}
+
+const fn default_http2() -> bool {
     true
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,33 @@ pub struct Secrets {
 pub struct Server {
     pub port: u16,
     pub host: String,
+
+    /// Sets `TCP_NODELAY` on accepted sockets, disabling Nagle's algorithm.
+    /// Defaults to `true`, which is the correct setting for a request/response
+    /// service and matches what nginx, Envoy and gRPC do.
+    ///
+    /// With Nagle active, two responses written back-to-back on one connection
+    /// stall: the second is held until the first is acknowledged, and the
+    /// peer's delayed-ACK timer adds ~40ms. Only set this to `false` to
+    /// deliberately reproduce that behaviour.
+    #[serde(default = "default_true")]
+    pub set_tcp_nodelay: bool,
+
+    /// Offers HTTP/2 via ALPN during the TLS handshake. Defaults to `true`.
+    ///
+    /// Only meaningful with the `mtls` feature: ALPN is a TLS extension, so a
+    /// plaintext listener speaks HTTP/1.1 regardless of this setting.
+    ///
+    /// With HTTP/2, concurrent requests from one client are multiplexed onto a
+    /// single connection, which keeps TLS handshake cost flat as concurrency
+    /// grows. Setting this to `false` forces clients onto HTTP/1.1, giving each
+    /// concurrent request its own connection.
+    #[serde(default = "default_true")]
+    pub enable_http2: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, serde::Deserialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,15 +208,8 @@ pub struct Secrets {
 pub struct Server {
     pub port: u16,
     pub host: String,
-
-    /// Disables Nagle's algorithm on accepted sockets. Leave enabled: with Nagle
-    /// active, back-to-back responses on one connection stall on the peer's
-    /// delayed-ACK timer (~40ms).
     #[serde(default = "default_tcp_nodelay")]
     pub set_tcp_nodelay: bool,
-
-    /// Offers HTTP/2 via ALPN. Only applies with the `mtls` feature, since ALPN
-    /// requires TLS; a plaintext listener is HTTP/1.1 either way.
     #[serde(default = "default_http2")]
     pub enable_http2: bool,
 }


### PR DESCRIPTION
## Description

This PR introduces two configurable options for the server.

| Key                | Default | Effect                                        |
| ------------------ | ------- | --------------------------------------------- |
| `set_tcp_nodelay`  | `true`  | Disables Nagle on accepted sockets            |

## Motivation

`axum_server::bind_rustls(...)` inherits `DefaultAcceptor`, a no-op that never calls `set_nodelay`, leaving Nagle's algorithm active. When two responses are written back-to-back on one multiplexed HTTP/2 connection, the second is held until the first is acknowledged — and the peer's delayed-ACK timer (40ms floor on Linux) supplies that acknowledgement only after the timeout.

## How did you test it?
This was deployed in a cloud environment with live traffic being served to it continuously - and saw no issues.