### PR TITLE
refactor: decouple management server from prometheus mode

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -5,7 +5,6 @@
 [server]
 host = "127.0.0.1" # IP address the HTTP server listens on
 port = 5000        # Port the HTTP server listens on. Use a port that does not conflict with other services.
-
 # Sets TCP_NODELAY on accepted sockets, disabling Nagle's algorithm.
 # (optional, default: true — the correct setting for a request/response service)
 #
@@ -13,6 +12,14 @@ port = 5000        # Port the HTTP server listens on. Use a port that does not c
 # the second waits on the first's acknowledgement, and the peer's delayed-ACK
 # timer adds ~40ms. Set false only to deliberately reproduce that behaviour.
 set_tcp_nodelay = true
+
+# Management server configuration
+# Plain HTTP listener that always runs.
+# Serves `/health` unconditionally, and `/metrics` when `metrics.mode` is `"prometheus"`.
+# Use this port for Kubernetes liveness and readiness probes when the main server enforces mTLS.
+[management_server]
+host = "127.0.0.1"  # IP address the management server listens on (optional, default: 127.0.0.1)
+port = 6128         # Port the management server listens on (optional, default: 6128)
 
 # Database configuration
 [database]
@@ -78,9 +85,8 @@ endpoint = "http://127.0.0.1:4317"                 # OTLP gRPC endpoint
 endpoint_timeout_secs = 10                         # Connection timeout in seconds
 metrics_export_interval_secs = 15                  # Export interval in seconds
 
-# When mode is "prometheus", configure the Prometheus HTTP server:
-# host = "127.0.0.1"                                # IP address the Prometheus HTTP server listens on
-# port = 6128                                       # Port the Prometheus HTTP server listens on
+# When mode is "prometheus", the `/metrics` endpoint is served on the management server.
+# See `[management_server]` section for host and port configuration.
 
 # Secrets and encryption configuration
 # The service supports three mutually exclusive key management strategies chosen at compile time:

--- a/config/development.toml
+++ b/config/development.toml
@@ -1,7 +1,9 @@
-[metrics]
-mode = "prometheus"
+[management_server]
 host = "127.0.0.1"
 port = 6128
+
+[metrics]
+mode = "prometheus"
 
 [pool_config]
 pool = 2

--- a/src/bin/cripta.rs
+++ b/src/bin/cripta.rs
@@ -21,6 +21,61 @@ fn default_headers() -> tower_http::set_header::SetResponseHeaderLayer<axum::htt
     )
 }
 
+async fn spawn_management_server(
+    host: &str,
+    port: u16,
+    prometheus_registry: Option<metrics_utils::prometheus::Registry>,
+    state: Arc<AppState>,
+) {
+    use metrics_utils::prometheus::Encoder;
+
+    #[expect(clippy::expect_used)]
+    let addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .expect("Unable to parse management server address");
+
+    let mut app = Router::new();
+
+    if let Some(registry) = prometheus_registry {
+        app = app.route(
+            "/metrics",
+            axum::routing::get(move || {
+                let registry = registry.clone();
+                async move {
+                    let encoder = metrics_utils::prometheus::TextEncoder::new();
+                    let mut buffer = Vec::new();
+
+                    if let Err(error) = encoder.encode(&registry.gather(), &mut buffer) {
+                        tracing::warn!(?error, "Failed to encode prometheus metrics");
+                    }
+
+                    (
+                        axum::http::StatusCode::OK,
+                        String::from_utf8(buffer).unwrap_or_default(),
+                    )
+                }
+            }),
+        );
+    }
+
+    let app = app
+        .nest("/health", Health::server(state.clone()))
+        .with_state(state);
+
+    #[expect(clippy::expect_used)]
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("Unable to bind management server");
+
+    tokio::spawn(async move {
+        tracing::info!("Starting management server at `{addr}`");
+
+        if let Err(error) = axum::serve(listener, app).await {
+            tracing::warn!(?error, "Management server failed");
+        }
+    });
+}
+
 #[expect(clippy::expect_used)]
 #[tokio::main]
 async fn main() {
@@ -95,18 +150,19 @@ async fn main() {
         .layer(middleware)
         .with_state(state.clone());
 
-    if let observability::MetricsHandle::Prometheus { inner, host, port } = guards.metrics_handle()
-        && let Some(registry) = inner.prometheus_registry()
-    {
-        // Spawn metrics server without mtls in a seperate port
-        observability::spawn_prometheus_metrics_server(
-            host,
-            *port,
-            registry.clone(),
-            state.clone(),
-        )
-        .expect("Failed to start Prometheus metrics server");
-    }
+    let prometheus_registry = match guards.metrics_handle() {
+        observability::MetricsHandle::Prometheus { inner } => inner.prometheus_registry().cloned(),
+        _ => None,
+    };
+
+    // Spawn management server without mtls in a separate port
+    spawn_management_server(
+        &state.conf.management_server.host,
+        state.conf.management_server.port,
+        prometheus_registry,
+        state.clone(),
+    )
+    .await;
 
     #[cfg(feature = "mtls")]
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,8 @@ pub struct PoolConfig {
 #[derive(Deserialize, Debug)]
 pub struct Config {
     pub server: Server,
+    #[serde(default)]
+    pub management_server: ManagementServer,
     pub database: Database,
     pub secrets: Secrets,
     #[serde(default)]
@@ -216,6 +218,43 @@ const fn default_tcp_nodelay() -> bool {
     true
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ManagementServer {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for ManagementServer {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 6128,
+        }
+    }
+}
+
+impl ManagementServer {
+    pub fn validate(&self) -> CustomResult<(), errors::ParsingError> {
+        if self.host.parse::<std::net::IpAddr>().is_err() {
+            return Err(error_stack::Report::new(
+                errors::ParsingError::DecodingFailed(
+                    r#"management_server.host must be a valid IP address"#.into(),
+                ),
+            ));
+        }
+
+        if self.port == 0 {
+            return Err(error_stack::Report::new(
+                errors::ParsingError::DecodingFailed(
+                    r#"management_server.port must be a non-zero value"#.into(),
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum MetricsConfig {
@@ -230,12 +269,7 @@ pub enum MetricsConfig {
         metrics_export_interval_secs: u64,
     },
 
-    Prometheus {
-        #[serde(default = "default_prometheus_host")]
-        host: String,
-        #[serde(default = "default_prometheus_port")]
-        port: u16,
-    },
+    Prometheus,
 }
 
 const fn default_endpoint_timeout() -> u64 {
@@ -244,14 +278,6 @@ const fn default_endpoint_timeout() -> u64 {
 
 const fn default_export_interval() -> u64 {
     15
-}
-
-fn default_prometheus_host() -> String {
-    "127.0.0.1".to_string()
-}
-
-const fn default_prometheus_port() -> u16 {
-    6128
 }
 
 impl MetricsConfig {
@@ -268,25 +294,7 @@ impl MetricsConfig {
                 }
                 Ok(())
             }
-            Self::Prometheus { host, port, .. } => {
-                if host.parse::<std::net::IpAddr>().is_err() {
-                    return Err(error_stack::Report::new(
-                        errors::ParsingError::DecodingFailed(
-                            r#"metrics.host must be a valid IP address when mode is "prometheus""#
-                                .into(),
-                        ),
-                    ));
-                }
-                if *port == 0 {
-                    return Err(error_stack::Report::new(
-                        errors::ParsingError::DecodingFailed(
-                            r#"metrics.port must be a non-zero value when mode is "prometheus""#
-                                .into(),
-                        ),
-                    ));
-                }
-                Ok(())
-            }
+            Self::Prometheus => Ok(()),
         }
     }
 }
@@ -409,6 +417,10 @@ impl Config {
     /// Panics for a validation fail
     #[allow(clippy::panic, clippy::expect_used)]
     pub fn validate(&self) {
+        self.management_server
+            .validate()
+            .expect("Failed to validate management server configuration");
+
         self.secrets
             .validate()
             .expect("Failed to valdiate secrets some missing configuration found");

--- a/src/env/metrics.rs
+++ b/src/env/metrics.rs
@@ -1,27 +1,20 @@
 mod middleware;
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
-use axum::Router;
 use metrics_utils::{
     counter_metric, f64_histogram_buckets, global_meter, histogram_metric_f64,
     up_down_counter_metric,
 };
 
 pub use self::middleware::HttpRequestMetricsLayer;
-use crate::{app::AppState, config::MetricsConfig, errors, routes::Health};
+use crate::config::MetricsConfig;
 
 #[derive(Debug)]
 pub enum MetricsHandle {
     Disabled,
-    Otlp {
-        inner: metrics_utils::MetricsHandle,
-    },
-    Prometheus {
-        inner: metrics_utils::MetricsHandle,
-        host: String,
-        port: u16,
-    },
+    Otlp { inner: metrics_utils::MetricsHandle },
+    Prometheus { inner: metrics_utils::MetricsHandle },
 }
 
 impl MetricsHandle {
@@ -70,7 +63,7 @@ pub fn init_metrics(config: &MetricsConfig, service_name: &'static str) -> Metri
             }
         }
 
-        MetricsConfig::Prometheus { host, port, .. } => {
+        MetricsConfig::Prometheus => {
             let metrics_config = metrics_utils::MetricsConfig {
                 service_name: String::from(service_name),
                 resource_attributes: Vec::new(),
@@ -81,11 +74,7 @@ pub fn init_metrics(config: &MetricsConfig, service_name: &'static str) -> Metri
             match metrics_utils::init_metrics(&metrics_config) {
                 Ok(inner) => {
                     inner.register_as_global();
-                    MetricsHandle::Prometheus {
-                        inner,
-                        host: host.clone(),
-                        port: *port,
-                    }
+                    MetricsHandle::Prometheus { inner }
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -97,66 +86,6 @@ pub fn init_metrics(config: &MetricsConfig, service_name: &'static str) -> Metri
             }
         }
     }
-}
-
-pub fn spawn_prometheus_metrics_server(
-    host: &str,
-    port: u16,
-    registry: metrics_utils::prometheus::Registry,
-    state: Arc<AppState>,
-) -> errors::CustomResult<(), errors::ParsingError> {
-    use metrics_utils::prometheus::Encoder;
-
-    let addr = match host.parse::<std::net::IpAddr>() {
-        Ok(ip) => std::net::SocketAddr::new(ip, port),
-        Err(_) => {
-            return Err(error_stack::Report::new(
-                errors::ParsingError::DecodingFailed(format!(
-                    r#"metrics.host "{host}" is not a valid IP address"#
-                )),
-            ));
-        }
-    };
-
-    let app = Router::new()
-        .route(
-            "/metrics",
-            axum::routing::get(move || {
-                let registry = registry.clone();
-                async move {
-                    let encoder = metrics_utils::prometheus::TextEncoder::new();
-                    let mut buffer = Vec::new();
-
-                    if let Err(error) = encoder.encode(&registry.gather(), &mut buffer) {
-                        tracing::warn!(?error, "Failed to encode prometheus metrics");
-                    }
-
-                    (
-                        axum::http::StatusCode::OK,
-                        String::from_utf8(buffer).unwrap_or_default(),
-                    )
-                }
-            }),
-        )
-        .nest("/health", Health::server(state.clone()))
-        .with_state(state);
-
-    tokio::spawn(async move {
-        match tokio::net::TcpListener::bind(addr).await {
-            Ok(listener) => {
-                tracing::info!("Starting Prometheus metrics server at `{addr}`");
-
-                if let Err(error) = axum::serve(listener, app).await {
-                    tracing::warn!(?error, "Prometheus metrics server failed");
-                }
-            }
-            Err(error) => {
-                tracing::error!(?error, "Failed to bind prometheus metrics server");
-            }
-        }
-    });
-
-    Ok(())
 }
 
 global_meter!(pub(crate) CRIPTA_METER, "encryption_service");

--- a/src/env/observability.rs
+++ b/src/env/observability.rs
@@ -6,7 +6,7 @@ use super::{
 };
 pub use super::{
     logger::{LogConfig, LogLevel},
-    metrics::{HttpRequestMetricsLayer, MetricsHandle, spawn_prometheus_metrics_server},
+    metrics::{HttpRequestMetricsLayer, MetricsHandle},
 };
 use crate::config::Config;
 


### PR DESCRIPTION
### Description

This PR decouples the plain HTTP server serving the `/health` (for liveness/readiness probes) and `/metrics` endpoint as a "management server", which would be available in all metrics modes. Previously, the secondary server (including the secondary health endpoint) was only available when `metrics.mode` was `prometheus`. This was a bug, addressed in this PR.

As part of this change, a new configuration section is available for `[management_server]` to configure the management server. It serves the `/health` endpoint without mTLS in all cases, and serves `/metrics` endpoint only in Prometheus metrics mode.

### Testing

- Tried hitting the secondary `/health` endpoint with all metrics modes, it returns a successful response.
- Tried hitting the `/metrics` endpoint with all metrics modes, it only returned metrics in case of Prometheus metrics mode, and returns a 404 status code in case metrics are disabled or OTLP mode is used.
- With OTLP metrics mode, metrics are properly being exported to the OpenTelemetry collector, I've tested this by running the collector locally.