### PR TITLE
feat: add GCP Cloud KMS backend, make secrets backend a runtime toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,7 +389,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -561,7 +567,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -618,6 +624,12 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1138,6 +1150,7 @@ dependencies = [
  "diesel-async",
  "error-stack",
  "futures",
+ "google-cloud-kms",
  "hex",
  "hyper 1.11.0",
  "hyperswitch_masking",
@@ -1160,7 +1173,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http 0.7.0",
  "tracing",
  "tracing-appender",
@@ -1722,6 +1735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1761,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2836,6 +2874,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de13e62d7e0ffc3eb40a0113ddf753cf6ec741be739164442b08893db4f9bfca"
+dependencies = [
+ "google-cloud-token",
+ "http 1.5.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-retry2",
+ "tonic 0.12.3",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
+dependencies = [
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "google-cloud-kms"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8842723521d34b9bf43305c84fd469c4d1858c42a630e1cb8c0d9c53781551"
+dependencies = [
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types 0.13.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-metadata"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
+dependencies = [
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +2971,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2866,7 +2990,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2892,6 +3016,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2968,6 +3098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3133,6 +3272,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3306,6 +3461,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3493,6 +3658,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3838,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3686,6 +3876,23 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3788,10 +3995,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3813,10 +4057,10 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.4",
  "thiserror 2.0.20",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-types",
 ]
 
@@ -3840,8 +4084,8 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.4",
+ "tonic 0.14.6",
  "tonic-prost",
 ]
 
@@ -3919,6 +4163,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4176,12 +4430,35 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4199,11 +4476,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4286,11 +4572,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -4307,12 +4604,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4414,6 +4730,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4438,7 +4792,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
- "tower",
+ "tower 0.5.3",
  "tower-http 0.6.11",
  "tower-service",
  "url",
@@ -4510,7 +4864,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.5.0",
- "reqwest",
+ "reqwest 0.13.4",
  "rustify_derive",
  "serde",
  "serde_json",
@@ -4566,7 +4920,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.14",
  "subtle",
@@ -4583,6 +4939,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4987,6 +5352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,6 +5372,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint 0.4.8",
+ "num-traits",
+ "thiserror 2.0.20",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -5395,6 +5778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5432,6 +5825,16 @@ dependencies = [
  "tokio-postgres",
  "tokio-rustls 0.26.4",
  "x509-cert",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0a122635e32bd827df297f311ca5e0292636bbd82f67ff84a4bedeab06dbeb"
+dependencies = [
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -5512,6 +5915,36 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
@@ -5530,7 +5963,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5544,8 +5977,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.4",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -5554,9 +5987,29 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.7",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5567,7 +6020,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5590,7 +6043,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -5608,7 +6061,7 @@ dependencies = [
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5850,7 +6303,7 @@ dependencies = [
  "async-trait",
  "derive_builder",
  "http 1.5.0",
- "reqwest",
+ "reqwest 0.13.4",
  "rustify",
  "rustify_derive",
  "serde",
@@ -6051,6 +6504,24 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,18 @@ rust-version = "1.92.0"
 [features]
 aes = []
 mtls = ["dep:rustls", "axum-server/tls-rustls"]
-aws = []
+aws = ["dep:aws-config", "dep:aws-sdk-kms"]
+gcp = ["dep:google-cloud-kms"]
 vergen = ["build_info/vergen-gix", "build_info/vergen-gix-build"]
-release = ["aws", "mtls", "postgres_ssl", "vergen"]
-vault = []
+release = ["aws", "gcp", "vault", "mtls", "postgres_ssl", "vergen"]
+vault = ["dep:vaultrs"]
 postgres_ssl = ["dep:rustls", "dep:rustls-native-certs", "dep:tokio-postgres-rustls", "rustls/aws_lc_rs"]
 cassandra = []
 
 [dependencies]
 async-trait = "0.1.92"
-aws-config = { version = "1.8.18" }
-aws-sdk-kms = { version = "1.111.0" }
+aws-config = { version = "1.8.18", optional = true }
+aws-sdk-kms = { version = "1.111.0", optional = true }
 axum = { version = "0.8.9", features = ["macros"] }
 axum-server = "0.8.0"
 base64 = "0.23.1"
@@ -29,6 +30,7 @@ diesel = { version = "2.3.12", features = ["postgres", "serde_json", "time"] }
 diesel-async = { version = "0.9.2", features = ["postgres", "bb8"] }
 error-stack = "0.8.0"
 futures = "0.3.34"
+google-cloud-kms = { version = "0.6.0", optional = true }
 hex = "0.4.3"
 hyper = "1.11.0"
 hyperswitch_masking = { version = "0.0.1", features = ["cassandra", "diesel", "serde"] }
@@ -56,7 +58,7 @@ tracing = "0.1.44"
 tracing-appender = "0.2.5"
 tracing-subscriber = { version = "0.3.23", default-features = true, features = ["env-filter", "json", "registry"] }
 uuid = { version = "1.24.0", features = ["v7", "fast-rng"] }
-vaultrs = { version = "0.8.0" }
+vaultrs = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The encryption service mainly has following functionalities:-
 - Application communicates with the service to create a key for the specific entity.
 - Next time application has to encrypt/decrypt the data related to the entity, it has to send the entity identifier and the base64-encoded data, the Key Manager will encrypt/decrypt it for the application.
 - All the communication between application and the encryption service are authorised by Mutual TLS
-- All the Data Encryption Keys are Encrypted by either by securely generated AES-256 Key or a hosted Key Management Service (AWS KMS, Hashicorp Vault etc.)
+- All the Data Encryption Keys are Encrypted by either a securely generated local AES-256 Key or a hosted Key Management Service (AWS KMS, GCP Cloud KMS, HashiCorp Vault), selected at runtime via the `secrets.manager` config value.
 
 ![Architectural diagram](./docs/images/FlowDiagram.png)
 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -80,7 +80,7 @@ metrics_export_interval_secs = 15                  # Export interval in seconds
 # Secrets and encryption configuration
 # The service supports four mutually exclusive key management strategies, selected at
 # runtime by the `manager` field below:
-#   - "aes_local" (default, no feature flag needed) - a locally-held AES-256 master key
+#   - "aes_local" (no feature flag needed, but unavailable in `release` builds) - a locally-held AES-256 master key
 #   - "aws_kms" (requires the `aws` compile-time feature flag)
 #   - "gcp_kms" (requires the `gcp` compile-time feature flag)
 #   - "hashicorp_vault" (requires the `vault` compile-time feature flag)
@@ -90,7 +90,7 @@ metrics_export_interval_secs = 15                  # Export interval in seconds
 manager = "aes_local"
 # Local AES-256 master key (32 bytes / 64 hex characters) - required when manager = "aes_local".
 # Replace this value with a key generated from a cryptographically secure source.
-aes_local = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
+master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
 
 # AWS KMS configuration - required when manager = "aws_kms"
 # [secrets.aws_kms]

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -60,6 +60,9 @@ log_format = "console"                     # Log output format. Possible values:
                                            # Overrides log levels for specific modules.
                                            # The default level applies to all modules not listed.
 
+# Uncomment when secrets.manager = "aws_kms" to avoid a tracing-subscriber panic on AWS SDK spans.
+# filtering_directive = "WARN,cripta=DEBUG,tower_http=DEBUG,aws_config=DEBUG,aws_smithy_runtime=DEBUG,aws_sdk_kms=DEBUG,aws_runtime=DEBUG"
+
 # Metrics configuration
 # Mode determines which metrics exporter to use.
 [metrics]
@@ -75,25 +78,36 @@ metrics_export_interval_secs = 15                  # Export interval in seconds
 # port = 6128                                       # Port the Prometheus HTTP server listens on
 
 # Secrets and encryption configuration
-# The service supports three mutually exclusive key management strategies chosen at compile time:
-#   - Local AES-256 (default, no feature flag needed)
-#   - AWS KMS (requires the `aws` feature flag)
-#   - HashiCorp Vault (requires the `vault` feature flag)
+# The service supports four mutually exclusive key management strategies, selected at
+# runtime by the `manager` field below:
+#   - "aes_local" (default, no feature flag needed) - a locally-held AES-256 master key
+#   - "aws_kms" (requires the `aws` compile-time feature flag)
+#   - "gcp_kms" (requires the `gcp` compile-time feature flag)
+#   - "hashicorp_vault" (requires the `vault` compile-time feature flag)
+# The corresponding sub-table below (e.g. [secrets.aws_kms]) must be present for
+# whichever manager is selected.
 [secrets]
-# Local AES-256 master key (32 bytes / 64 hex characters)
-# Used when neither the `aws` nor `vault` feature flag is enabled.
+manager = "aes_local"
+# Local AES-256 master key (32 bytes / 64 hex characters) - required when manager = "aes_local".
 # Replace this value with a key generated from a cryptographically secure source.
-master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
+aes_local = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
 
-# AWS KMS configuration - uncomment and configure when the `aws` feature flag is enabled
-# [secrets.kms_config]
+# AWS KMS configuration - required when manager = "aws_kms"
+# [secrets.aws_kms]
 # key_id = "arn:aws:kms:us-east-1:123456789012:key/abc123..." # AWS KMS key identifier
 # region = "us-east-1"                                        # AWS region for KMS requests
 # skip_key_id_on_decrypt = false                              # When true, omits key_id from decrypt requests.
                                                               # AWS KMS determines the key from ciphertext metadata.
 
-# HashiCorp Vault configuration - uncomment and configure when the `vault` feature flag is enabled
-# [secrets.vault_config]
+# GCP Cloud KMS configuration - required when manager = "gcp_kms"
+# [secrets.gcp_kms]
+# project_id = "my-gcp-project"        # GCP project ID that owns the KMS key ring
+# location_id = "us-east1"             # GCP location ID of the KMS key ring (e.g. "global", "us-east1")
+# key_ring_id = "cripta-keyring"       # GCP KMS key ring ID
+# key_id = "cripta-master-key"         # GCP KMS key ID
+
+# HashiCorp Vault configuration - required when manager = "hashicorp_vault"
+# [secrets.hashicorp_vault]
 # url = "http://127.0.0.1:8200"   # HashiCorp Vault server URL
 # mount_point = "transit"         # Vault transit engine mount point
 # encryption_key = "cripta-key"   # Name of the encryption key in Vault

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -60,9 +60,6 @@ log_format = "console"                     # Log output format. Possible values:
                                            # Overrides log levels for specific modules.
                                            # The default level applies to all modules not listed.
 
-# Uncomment when secrets.manager = "aws_kms" to avoid a tracing-subscriber panic on AWS SDK spans.
-# filtering_directive = "WARN,cripta=DEBUG,tower_http=DEBUG,aws_config=DEBUG,aws_smithy_runtime=DEBUG,aws_sdk_kms=DEBUG,aws_runtime=DEBUG"
-
 # Metrics configuration
 # Mode determines which metrics exporter to use.
 [metrics]
@@ -88,7 +85,9 @@ metrics_export_interval_secs = 15                  # Export interval in seconds
 # whichever manager is selected.
 [secrets]
 manager = "aes_local"
+
 # Local AES-256 master key (32 bytes / 64 hex characters) - required when manager = "aes_local".
+[secrets.aes_local]
 # Replace this value with a key generated from a cryptographically secure source.
 master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
 

--- a/config/development.toml
+++ b/config/development.toml
@@ -39,4 +39,4 @@ filtering_directive = "WARN,cripta=DEBUG,tower_http=DEBUG,aws_config=DEBUG,aws_s
 
 [secrets]
 manager = "aes_local"
-aes_local = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
+master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"

--- a/config/development.toml
+++ b/config/development.toml
@@ -34,6 +34,9 @@ schema = "global"
 enabled = true
 log_level = "debug"
 log_format = "console"
+# Required when secrets.manager = "aws_kms", to avoid a tracing-subscriber panic on AWS SDK spans.
+filtering_directive = "WARN,cripta=DEBUG,tower_http=DEBUG,aws_config=DEBUG,aws_smithy_runtime=DEBUG,aws_sdk_kms=DEBUG,aws_runtime=DEBUG"
 
 [secrets]
-master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"
+manager = "aes_local"
+aes_local = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"

--- a/config/development.toml
+++ b/config/development.toml
@@ -34,9 +34,9 @@ schema = "global"
 enabled = true
 log_level = "debug"
 log_format = "console"
-# Required when secrets.manager = "aws_kms", to avoid a tracing-subscriber panic on AWS SDK spans.
-filtering_directive = "WARN,cripta=DEBUG,tower_http=DEBUG,aws_config=DEBUG,aws_smithy_runtime=DEBUG,aws_sdk_kms=DEBUG,aws_runtime=DEBUG"
 
 [secrets]
 manager = "aes_local"
+
+[secrets.aes_local]
 master_key = "6d761d32f1b14ef34cf016d726b29b02b5cfce92a8959f1bfb65995c8100925e"

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,7 +71,10 @@ impl SessionState {
 
         Self {
             caches: Caches::from_config(&config.cache, tenant_id),
-            keymanager_client: secrets.create_keymanager_client().await,
+            keymanager_client: secrets
+                .create_keymanager_client()
+                .await
+                .expect("Failed to create the key management client"),
             db_pool,
             thread_pool: ThreadPoolBuilder::new()
                 .num_threads(num_threads)

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,25 +4,31 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(feature = "aws")]
 use aws_sdk_kms::primitives::Blob;
 use config::File;
+#[cfg(feature = "gcp")]
+use google_cloud_kms::grpc::kms::v1::DecryptRequest;
+#[cfg(any(feature = "aws", feature = "gcp", feature = "vault"))]
 use hyperswitch_masking::PeekInterface;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+#[cfg(feature = "vault")]
 use vaultrs::{
     client::{VaultClient, VaultClientSettingsBuilder},
     transit,
 };
 
+#[cfg(feature = "vault")]
+use crate::crypto::vault::{Vault, VaultSettings};
+#[cfg(feature = "aws")]
+use crate::services::aws::{AwsKmsClient, AwsKmsConfig};
+#[cfg(feature = "gcp")]
+use crate::services::gcp::{GcpKmsClient, GcpKmsConfig};
 use crate::{
-    crypto::{
-        KeyManagerClient,
-        aes256::GcmAes256,
-        vault::{Vault, VaultSettings},
-    },
+    crypto::{KeyManagerClient, aes256::GcmAes256},
     env::observability::LogConfig,
     errors::{self, CustomResult},
-    services::aws::{AwsKmsClient, AwsKmsConfig},
 };
 
 pub mod vars {
@@ -59,69 +65,104 @@ pub struct SecretContainer(hyperswitch_masking::Secret<String>);
 impl SecretContainer {
     /// # Panics
     ///
-    /// Panics when secret cannot be decrypted with KMS
+    /// Panics when secret cannot be decrypted with the configured backend.
     #[allow(clippy::expect_used, unused_variables)]
     pub async fn expose(&self, config: &Config) -> hyperswitch_masking::Secret<String> {
-        if cfg!(feature = "aws") {
-            use base64::Engine;
+        match &config.secrets {
+            #[cfg(feature = "aws")]
+            Secrets::AwsKms { aws_kms } => {
+                use base64::Engine;
 
-            let kms = AwsKmsClient::new(&config.secrets.kms_config).await;
-            let data = crate::consts::base64::BASE64_ENGINE
-                .decode(self.0.peek())
-                .expect("Unable to base64 decode secret");
+                let kms = AwsKmsClient::new(aws_kms).await;
+                let data = crate::consts::base64::BASE64_ENGINE
+                    .decode(self.0.peek())
+                    .expect("Unable to base64 decode secret");
 
-            let plaintext_blob = Blob::new(data);
-            let mut decrypt_request = kms.inner_client().decrypt().ciphertext_blob(plaintext_blob);
+                let plaintext_blob = Blob::new(data);
+                let mut decrypt_request =
+                    kms.inner_client().decrypt().ciphertext_blob(plaintext_blob);
 
-            if !kms.skip_key_id_on_decrypt() {
-                decrypt_request = decrypt_request.key_id(kms.key_id());
+                if !kms.skip_key_id_on_decrypt() {
+                    decrypt_request = decrypt_request.key_id(kms.key_id());
+                }
+
+                let decrypted_output = decrypt_request
+                    .send()
+                    .await
+                    .expect("Unable to decrypt KMS encrypted secret")
+                    .plaintext
+                    .expect("Plaintext secret is empty")
+                    .into_inner();
+
+                let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
+                hyperswitch_masking::Secret::new(secret)
             }
+            #[cfg(feature = "gcp")]
+            Secrets::GcpKms { gcp_kms } => {
+                use base64::Engine;
 
-            let decrypted_output = decrypt_request
-                .send()
-                .await
-                .expect("Unable to decrypt KMS encrypted secret")
-                .plaintext
-                .expect("Plaintext secret is empty")
-                .into_inner();
+                let client = GcpKmsClient::new(gcp_kms)
+                    .await
+                    .expect("Unable to build GCP KMS client");
 
-            let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
-            hyperswitch_masking::Secret::new(secret)
-        } else if cfg!(feature = "vault") {
-            use base64::Engine;
+                let ciphertext = crate::consts::base64::BASE64_ENGINE
+                    .decode(self.0.peek())
+                    .expect("Unable to base64 decode secret");
 
-            let client = VaultClient::new(
-                VaultClientSettingsBuilder::default()
-                    .address(&config.secrets.vault_config.url)
-                    .token(config.secrets.vault_config.vault_token.peek())
-                    .build()
-                    .expect("Unable to build HashiCorp Vault Settings"),
-            )
-            .expect("Unable to build HashiCorp Vault client");
+                let request = DecryptRequest {
+                    name: client.key_name().to_owned(),
+                    ciphertext,
+                    additional_authenticated_data: Vec::new(),
+                    ciphertext_crc32c: None,
+                    additional_authenticated_data_crc32c: None,
+                };
 
-            let ciphertext = self.0.peek();
+                let decrypted_output = client
+                    .inner_client()
+                    .decrypt(request, None)
+                    .await
+                    .expect("Unable to decrypt GCP KMS encrypted secret")
+                    .plaintext;
 
-            let b64_encoded_str = transit::data::decrypt(
-                &client,
-                &config.secrets.vault_config.mount_point,
-                &config.secrets.vault_config.encryption_key,
-                ciphertext,
-                None,
-            )
-            .await
-            .expect("Failed while decrypting vault encrypted secret")
-            .plaintext;
+                let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
+                hyperswitch_masking::Secret::new(secret)
+            }
+            #[cfg(feature = "vault")]
+            Secrets::HashicorpVault { hashicorp_vault } => {
+                use base64::Engine;
 
-            hyperswitch_masking::Secret::new(
-                String::from_utf8(
-                    crate::consts::base64::BASE64_ENGINE
-                        .decode(b64_encoded_str)
-                        .expect("Failed to base64 decode the vault data"),
+                let client = VaultClient::new(
+                    VaultClientSettingsBuilder::default()
+                        .address(&hashicorp_vault.url)
+                        .token(hashicorp_vault.vault_token.peek())
+                        .build()
+                        .expect("Unable to build HashiCorp Vault Settings"),
                 )
-                .expect("Invalid secret"),
-            )
-        } else {
-            self.0.clone()
+                .expect("Unable to build HashiCorp Vault client");
+
+                let ciphertext = self.0.peek();
+
+                let b64_encoded_str = transit::data::decrypt(
+                    &client,
+                    &hashicorp_vault.mount_point,
+                    &hashicorp_vault.encryption_key,
+                    ciphertext,
+                    None,
+                )
+                .await
+                .expect("Failed while decrypting vault encrypted secret")
+                .plaintext;
+
+                hyperswitch_masking::Secret::new(
+                    String::from_utf8(
+                        crate::consts::base64::BASE64_ENGINE
+                            .decode(b64_encoded_str)
+                            .expect("Failed to base64 decode the vault data"),
+                    )
+                    .expect("Invalid secret"),
+                )
+            }
+            Secrets::AesLocal { .. } => self.0.clone(),
         }
     }
 }
@@ -194,14 +235,24 @@ pub struct Certs {
     pub root_ca: SecretContainer,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct Secrets {
-    #[serde(default)]
-    pub master_key: GcmAes256,
-    #[serde(default)]
-    pub kms_config: AwsKmsConfig,
-    #[serde(default)]
-    pub vault_config: VaultSettings,
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "manager", rename_all = "snake_case")]
+pub enum Secrets {
+    #[cfg(feature = "aws")]
+    AwsKms {
+        aws_kms: AwsKmsConfig,
+    },
+    #[cfg(feature = "gcp")]
+    GcpKms {
+        gcp_kms: GcpKmsConfig,
+    },
+    #[cfg(feature = "vault")]
+    HashicorpVault {
+        hashicorp_vault: VaultSettings,
+    },
+    AesLocal {
+        aes_local: GcmAes256,
+    },
 }
 
 #[derive(Deserialize, Debug)]
@@ -306,18 +357,31 @@ impl Default for CacheConfig {
 
 impl Secrets {
     fn validate(&self) -> CustomResult<(), errors::ParsingError> {
-        if cfg!(feature = "aws") {
-            error_stack::ensure!(
-                !self.kms_config.eq(&AwsKmsConfig::default()),
-                errors::ParsingError::DecodingFailed("AWS config is not provided".to_string())
-            )
-        } else if cfg!(feature = "vault") {
-            error_stack::ensure!(
-                !self.vault_config.eq(&VaultSettings::default()),
-                errors::ParsingError::DecodingFailed("Vault config is not provided".to_string())
-            )
+        match self {
+            #[cfg(feature = "aws")]
+            Self::AwsKms { aws_kms } => {
+                error_stack::ensure!(
+                    !aws_kms.eq(&AwsKmsConfig::default()),
+                    errors::ParsingError::DecodingFailed("AWS config is not provided".to_string())
+                );
+                Ok(())
+            }
+            #[cfg(feature = "gcp")]
+            Self::GcpKms { gcp_kms } => gcp_kms.validate().map_err(|message| {
+                error_stack::Report::new(errors::ParsingError::DecodingFailed(message.to_string()))
+            }),
+            #[cfg(feature = "vault")]
+            Self::HashicorpVault { hashicorp_vault } => {
+                error_stack::ensure!(
+                    !hashicorp_vault.eq(&VaultSettings::default()),
+                    errors::ParsingError::DecodingFailed(
+                        "Vault config is not provided".to_string()
+                    )
+                );
+                Ok(())
+            }
+            Self::AesLocal { .. } => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -422,16 +486,26 @@ impl Config {
 }
 
 impl Secrets {
-    pub async fn create_keymanager_client(self) -> KeyManagerClient {
-        if cfg!(feature = "aws") {
-            let client = AwsKmsClient::new(&self.kms_config).await;
-            KeyManagerClient::new(Arc::new(client))
-        } else if cfg!(feature = "vault") {
-            let client = Vault::new(self.vault_config);
-            KeyManagerClient::new(Arc::new(client))
-        } else {
-            let client = self.master_key;
-            KeyManagerClient::new(Arc::new(client))
-        }
+    pub async fn create_keymanager_client(
+        self,
+    ) -> CustomResult<KeyManagerClient, errors::CryptoError> {
+        Ok(match self {
+            #[cfg(feature = "aws")]
+            Self::AwsKms { aws_kms } => {
+                let client = AwsKmsClient::new(&aws_kms).await;
+                KeyManagerClient::new(Arc::new(client))
+            }
+            #[cfg(feature = "gcp")]
+            Self::GcpKms { gcp_kms } => {
+                let client = GcpKmsClient::new(&gcp_kms).await?;
+                KeyManagerClient::new(Arc::new(client))
+            }
+            #[cfg(feature = "vault")]
+            Self::HashicorpVault { hashicorp_vault } => {
+                let client = Vault::new(hashicorp_vault);
+                KeyManagerClient::new(Arc::new(client))
+            }
+            Self::AesLocal { aes_local } => KeyManagerClient::new(Arc::new(aes_local)),
+        })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ use vaultrs::{
     transit,
 };
 
+#[cfg(not(feature = "release"))]
+use crate::crypto::aes256::GcmAes256;
 #[cfg(feature = "vault")]
 use crate::crypto::vault::{Vault, VaultSettings};
 #[cfg(feature = "aws")]
@@ -26,7 +28,7 @@ use crate::services::aws::{AwsKmsClient, AwsKmsConfig};
 #[cfg(feature = "gcp")]
 use crate::services::gcp::{GcpKmsClient, GcpKmsConfig};
 use crate::{
-    crypto::{KeyManagerClient, aes256::GcmAes256},
+    crypto::KeyManagerClient,
     env::observability::LogConfig,
     errors::{self, CustomResult},
 };
@@ -162,6 +164,7 @@ impl SecretContainer {
                     .expect("Invalid secret"),
                 )
             }
+            #[cfg(not(feature = "release"))]
             Secrets::AesLocal { .. } => self.0.clone(),
         }
     }
@@ -250,8 +253,9 @@ pub enum Secrets {
     HashicorpVault {
         hashicorp_vault: VaultSettings,
     },
+    #[cfg(not(feature = "release"))]
     AesLocal {
-        aes_local: GcmAes256,
+        master_key: GcmAes256,
     },
 }
 
@@ -380,6 +384,7 @@ impl Secrets {
                 );
                 Ok(())
             }
+            #[cfg(not(feature = "release"))]
             Self::AesLocal { .. } => Ok(()),
         }
     }
@@ -505,7 +510,8 @@ impl Secrets {
                 let client = Vault::new(hashicorp_vault);
                 KeyManagerClient::new(Arc::new(client))
             }
-            Self::AesLocal { aes_local } => KeyManagerClient::new(Arc::new(aes_local)),
+            #[cfg(not(feature = "release"))]
+            Self::AesLocal { master_key } => KeyManagerClient::new(Arc::new(master_key)),
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,21 +242,13 @@ pub struct Certs {
 #[serde(tag = "manager", rename_all = "snake_case")]
 pub enum Secrets {
     #[cfg(feature = "aws")]
-    AwsKms {
-        aws_kms: AwsKmsConfig,
-    },
+    AwsKms { aws_kms: AwsKmsConfig },
     #[cfg(feature = "gcp")]
-    GcpKms {
-        gcp_kms: GcpKmsConfig,
-    },
+    GcpKms { gcp_kms: GcpKmsConfig },
     #[cfg(feature = "vault")]
-    HashicorpVault {
-        hashicorp_vault: VaultSettings,
-    },
+    HashicorpVault { hashicorp_vault: VaultSettings },
     #[cfg(not(feature = "release"))]
-    AesLocal {
-        master_key: GcmAes256,
-    },
+    AesLocal { master_key: GcmAes256 },
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,23 +4,14 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(feature = "aws")]
-use aws_sdk_kms::primitives::Blob;
 use config::File;
-#[cfg(feature = "gcp")]
-use google_cloud_kms::grpc::kms::v1::DecryptRequest;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "vault"))]
 use hyperswitch_masking::PeekInterface;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-#[cfg(feature = "vault")]
-use vaultrs::{
-    client::{VaultClient, VaultClientSettingsBuilder},
-    transit,
-};
 
 #[cfg(not(feature = "release"))]
-use crate::crypto::aes256::GcmAes256;
+use crate::crypto::aes256::AesLocalConfig;
 #[cfg(feature = "vault")]
 use crate::crypto::vault::{Vault, VaultSettings};
 #[cfg(feature = "aws")]
@@ -73,96 +64,30 @@ impl SecretContainer {
         match &config.secrets {
             #[cfg(feature = "aws")]
             Secrets::AwsKms { aws_kms } => {
-                use base64::Engine;
-
-                let kms = AwsKmsClient::new(aws_kms).await;
-                let data = crate::consts::base64::BASE64_ENGINE
-                    .decode(self.0.peek())
-                    .expect("Unable to base64 decode secret");
-
-                let plaintext_blob = Blob::new(data);
-                let mut decrypt_request =
-                    kms.inner_client().decrypt().ciphertext_blob(plaintext_blob);
-
-                if !kms.skip_key_id_on_decrypt() {
-                    decrypt_request = decrypt_request.key_id(kms.key_id());
-                }
-
-                let decrypted_output = decrypt_request
-                    .send()
+                let secret = AwsKmsClient::new(aws_kms)
                     .await
-                    .expect("Unable to decrypt KMS encrypted secret")
-                    .plaintext
-                    .expect("Plaintext secret is empty")
-                    .into_inner();
-
-                let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
+                    .decrypt_secret(self.0.peek())
+                    .await
+                    .expect("Unable to decrypt AWS KMS encrypted secret");
                 hyperswitch_masking::Secret::new(secret)
             }
             #[cfg(feature = "gcp")]
             Secrets::GcpKms { gcp_kms } => {
-                use base64::Engine;
-
-                let client = GcpKmsClient::new(gcp_kms)
+                let secret = GcpKmsClient::new(gcp_kms)
                     .await
-                    .expect("Unable to build GCP KMS client");
-
-                let ciphertext = crate::consts::base64::BASE64_ENGINE
-                    .decode(self.0.peek())
-                    .expect("Unable to base64 decode secret");
-
-                let request = DecryptRequest {
-                    name: client.key_name().to_owned(),
-                    ciphertext,
-                    additional_authenticated_data: Vec::new(),
-                    ciphertext_crc32c: None,
-                    additional_authenticated_data_crc32c: None,
-                };
-
-                let decrypted_output = client
-                    .inner_client()
-                    .decrypt(request, None)
+                    .expect("Unable to build GCP KMS client")
+                    .decrypt_secret(self.0.peek())
                     .await
-                    .expect("Unable to decrypt GCP KMS encrypted secret")
-                    .plaintext;
-
-                let secret = String::from_utf8(decrypted_output).expect("Invalid secret");
+                    .expect("Unable to decrypt GCP KMS encrypted secret");
                 hyperswitch_masking::Secret::new(secret)
             }
             #[cfg(feature = "vault")]
             Secrets::HashicorpVault { hashicorp_vault } => {
-                use base64::Engine;
-
-                let client = VaultClient::new(
-                    VaultClientSettingsBuilder::default()
-                        .address(&hashicorp_vault.url)
-                        .token(hashicorp_vault.vault_token.peek())
-                        .build()
-                        .expect("Unable to build HashiCorp Vault Settings"),
-                )
-                .expect("Unable to build HashiCorp Vault client");
-
-                let ciphertext = self.0.peek();
-
-                let b64_encoded_str = transit::data::decrypt(
-                    &client,
-                    &hashicorp_vault.mount_point,
-                    &hashicorp_vault.encryption_key,
-                    ciphertext,
-                    None,
-                )
-                .await
-                .expect("Failed while decrypting vault encrypted secret")
-                .plaintext;
-
-                hyperswitch_masking::Secret::new(
-                    String::from_utf8(
-                        crate::consts::base64::BASE64_ENGINE
-                            .decode(b64_encoded_str)
-                            .expect("Failed to base64 decode the vault data"),
-                    )
-                    .expect("Invalid secret"),
-                )
+                let secret = Vault::new(hashicorp_vault.clone())
+                    .decrypt_secret(self.0.peek())
+                    .await
+                    .expect("Unable to decrypt HashiCorp Vault encrypted secret");
+                hyperswitch_masking::Secret::new(secret)
             }
             #[cfg(not(feature = "release"))]
             Secrets::AesLocal { .. } => self.0.clone(),
@@ -248,7 +173,7 @@ pub enum Secrets {
     #[cfg(feature = "vault")]
     HashicorpVault { hashicorp_vault: VaultSettings },
     #[cfg(not(feature = "release"))]
-    AesLocal { master_key: GcmAes256 },
+    AesLocal { aes_local: AesLocalConfig },
 }
 
 #[derive(Deserialize, Debug)]
@@ -355,26 +280,20 @@ impl Secrets {
     fn validate(&self) -> CustomResult<(), errors::ParsingError> {
         match self {
             #[cfg(feature = "aws")]
-            Self::AwsKms { aws_kms } => {
-                error_stack::ensure!(
-                    !aws_kms.eq(&AwsKmsConfig::default()),
-                    errors::ParsingError::DecodingFailed("AWS config is not provided".to_string())
-                );
-                Ok(())
-            }
+            Self::AwsKms { aws_kms } => aws_kms.validate().map_err(|message| {
+                error_stack::Report::new(errors::ParsingError::DecodingFailed(message.to_string()))
+            }),
             #[cfg(feature = "gcp")]
             Self::GcpKms { gcp_kms } => gcp_kms.validate().map_err(|message| {
                 error_stack::Report::new(errors::ParsingError::DecodingFailed(message.to_string()))
             }),
             #[cfg(feature = "vault")]
             Self::HashicorpVault { hashicorp_vault } => {
-                error_stack::ensure!(
-                    !hashicorp_vault.eq(&VaultSettings::default()),
-                    errors::ParsingError::DecodingFailed(
-                        "Vault config is not provided".to_string()
-                    )
-                );
-                Ok(())
+                hashicorp_vault.validate().map_err(|message| {
+                    error_stack::Report::new(errors::ParsingError::DecodingFailed(
+                        message.to_string(),
+                    ))
+                })
             }
             #[cfg(not(feature = "release"))]
             Self::AesLocal { .. } => Ok(()),
@@ -503,7 +422,7 @@ impl Secrets {
                 KeyManagerClient::new(Arc::new(client))
             }
             #[cfg(not(feature = "release"))]
-            Self::AesLocal { master_key } => KeyManagerClient::new(Arc::new(master_key)),
+            Self::AesLocal { aes_local } => KeyManagerClient::new(Arc::new(aes_local.master_key)),
         })
     }
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,8 +1,8 @@
 pub(crate) mod aes256;
-#[cfg(feature = "gcp")]
-pub(crate) mod gcp;
 #[cfg(feature = "aws")]
 pub(crate) mod aws;
+#[cfg(feature = "gcp")]
+pub(crate) mod gcp;
 #[cfg(feature = "vault")]
 pub(crate) mod vault;
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,5 +1,9 @@
 pub(crate) mod aes256;
-pub(crate) mod kms;
+#[cfg(feature = "gcp")]
+pub(crate) mod gcp;
+#[cfg(feature = "aws")]
+pub(crate) mod aws;
+#[cfg(feature = "vault")]
 pub(crate) mod vault;
 
 use std::{ops::Deref, sync::Arc};
@@ -7,11 +11,16 @@ use std::{ops::Deref, sync::Arc};
 use hyperswitch_masking::StrongSecret;
 use strum::{Display, EnumString};
 
+#[cfg(feature = "vault")]
+use crate::crypto::vault::Vault;
+#[cfg(feature = "aws")]
+use crate::services::aws::AwsKmsClient;
+#[cfg(feature = "gcp")]
+use crate::services::gcp::GcpKmsClient;
 use crate::{
-    crypto::{aes256::GcmAes256, vault::Vault},
+    crypto::aes256::GcmAes256,
     env::metrics,
     errors::{self, CustomResult},
-    services::aws::AwsKmsClient,
 };
 
 #[derive(Clone, EnumString, Display)]
@@ -19,6 +28,7 @@ pub enum Source {
     KMS,
     AESLocal,
     HashicorpVault,
+    GcpKms,
 }
 
 #[async_trait::async_trait]
@@ -49,6 +59,7 @@ pub trait KeyManagement {
     ) -> CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError>;
 }
 
+#[cfg(feature = "aws")]
 #[async_trait::async_trait]
 impl KeyManagement for AwsKmsClient {
     async fn generate_key(
@@ -124,6 +135,7 @@ impl KeyManagement for GcmAes256 {
     }
 }
 
+#[cfg(feature = "vault")]
 #[async_trait::async_trait]
 impl KeyManagement for Vault {
     async fn generate_key(
@@ -156,6 +168,45 @@ impl KeyManagement for Vault {
         record_key_manager_call(
             <Self as Crypto>::decrypt(self, input),
             metrics::KeyManagerBackend::Vault,
+            metrics::KeyManagerOperation::Decrypt,
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "gcp")]
+#[async_trait::async_trait]
+impl KeyManagement for GcpKmsClient {
+    async fn generate_key(
+        &self,
+    ) -> CustomResult<(Source, StrongSecret<[u8; 32]>), errors::CryptoError> {
+        record_key_manager_call(
+            <Self as Crypto>::generate_key(self),
+            metrics::KeyManagerBackend::GcpKms,
+            metrics::KeyManagerOperation::GenerateKey,
+        )
+        .await
+    }
+
+    async fn encrypt_key(
+        &self,
+        input: StrongSecret<Vec<u8>>,
+    ) -> CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError> {
+        record_key_manager_call(
+            <Self as Crypto>::encrypt(self, input),
+            metrics::KeyManagerBackend::GcpKms,
+            metrics::KeyManagerOperation::Encrypt,
+        )
+        .await
+    }
+
+    async fn decrypt_key(
+        &self,
+        input: StrongSecret<Vec<u8>>,
+    ) -> CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError> {
+        record_key_manager_call(
+            <Self as Crypto>::decrypt(self, input),
+            metrics::KeyManagerBackend::GcpKms,
             metrics::KeyManagerOperation::Decrypt,
         )
         .await

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use error_stack::{IntoReport, ResultExt};
+use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, StrongSecret};
 use ring::aead::{self, BoundKey, OpeningKey, SealingKey, UnboundKey};
 use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
@@ -21,15 +21,6 @@ impl GcmAes256 {
     }
     pub fn new(key: StrongSecret<[u8; 32]>) -> errors::CustomResult<Self, errors::CryptoError> {
         Ok(Self { key })
-    }
-
-    pub async fn from_vec(
-        key: StrongSecret<Vec<u8>>,
-    ) -> errors::CustomResult<Self, errors::CryptoError> {
-        let key = <[u8; 32]>::try_from(key.peek().to_vec())
-            .map_err(|_| errors::CryptoError::InvalidKey.into_report())?;
-
-        Ok(Self { key: key.into() })
     }
 }
 

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -24,6 +24,13 @@ impl GcmAes256 {
     }
 }
 
+/// `GcmAes256`'s `Deserialize` only accepts a plain string.
+#[cfg(not(feature = "release"))]
+#[derive(Clone, Debug, Default, serde::Deserialize)]
+pub struct AesLocalConfig {
+    pub master_key: GcmAes256,
+}
+
 #[derive(Clone, Debug)]
 struct NonceSequence(u128);
 

--- a/src/crypto/aes256.rs
+++ b/src/crypto/aes256.rs
@@ -24,7 +24,7 @@ impl GcmAes256 {
     }
 }
 
-/// `GcmAes256`'s `Deserialize` only accepts a plain string.
+// `GcmAes256`'s `Deserialize` only accepts a plain string.
 #[cfg(not(feature = "release"))]
 #[derive(Clone, Debug, Default, serde::Deserialize)]
 pub struct AesLocalConfig {

--- a/src/crypto/aws.rs
+++ b/src/crypto/aws.rs
@@ -69,8 +69,6 @@ impl Crypto for AwsKmsClient {
                 .decrypt()
                 .ciphertext_blob(plaintext_blob);
 
-            // Only include key_id in decrypt if skip_key_id_on_decrypt is false
-            // When true, KMS determines the key from the ciphertext metadata
             if !self.skip_key_id_on_decrypt() {
                 decrypt_request = decrypt_request.key_id(self.key_id());
             }

--- a/src/crypto/aws.rs
+++ b/src/crypto/aws.rs
@@ -63,11 +63,11 @@ impl Crypto for AwsKmsClient {
     }
     fn decrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
         Box::pin(async move {
-            let plaintext_blob = Blob::new(input.peek().to_vec());
+            let ciphertext_blob = Blob::new(input.peek().to_vec());
             let mut decrypt_request = self
                 .inner_client()
                 .decrypt()
-                .ciphertext_blob(plaintext_blob);
+                .ciphertext_blob(ciphertext_blob);
 
             // Only include key_id in decrypt if skip_key_id_on_decrypt is false
             // When true, KMS determines the key from the ciphertext metadata
@@ -75,11 +75,11 @@ impl Crypto for AwsKmsClient {
                 decrypt_request = decrypt_request.key_id(self.key_id());
             }
 
-            let encrypted_output = decrypt_request.send().await.switch()?;
+            let decrypted_output = decrypt_request.send().await.switch()?;
 
-            let output = encrypted_output
+            let output = decrypted_output
                 .plaintext
-                .ok_or(errors::CryptoError::EncryptionFailed("KMS").into_report())?;
+                .ok_or(errors::CryptoError::DecryptionFailed("KMS").into_report())?;
 
             Ok(output.into_inner().into())
         })

--- a/src/crypto/aws.rs
+++ b/src/crypto/aws.rs
@@ -69,6 +69,8 @@ impl Crypto for AwsKmsClient {
                 .decrypt()
                 .ciphertext_blob(plaintext_blob);
 
+            // Only include key_id in decrypt if skip_key_id_on_decrypt is false
+            // When true, KMS determines the key from the ciphertext metadata
             if !self.skip_key_id_on_decrypt() {
                 decrypt_request = decrypt_request.key_id(self.key_id());
             }

--- a/src/crypto/gcp.rs
+++ b/src/crypto/gcp.rs
@@ -1,0 +1,93 @@
+use std::pin::Pin;
+
+use error_stack::{IntoReport, ResultExt};
+use futures::Future;
+use google_cloud_kms::grpc::kms::v1::{
+    DecryptRequest, EncryptRequest, GenerateRandomBytesRequest, ProtectionLevel,
+};
+use hyperswitch_masking::{PeekInterface, StrongSecret};
+
+use crate::{
+    crypto::{Crypto, Source},
+    env::observability as logger,
+    errors::{self, CustomResult},
+    services::gcp::GcpKmsClient,
+};
+
+#[async_trait::async_trait]
+impl Crypto for GcpKmsClient {
+    type DataReturn<'a> = Pin<
+        Box<
+            dyn Future<Output = CustomResult<StrongSecret<Vec<u8>>, errors::CryptoError>>
+                + Send
+                + 'a,
+        >,
+    >;
+
+    async fn generate_key(
+        &self,
+    ) -> errors::CustomResult<(Source, StrongSecret<[u8; 32]>), errors::CryptoError> {
+        let request = GenerateRandomBytesRequest {
+            location: self.location().to_owned(),
+            length_bytes: 32,
+            protection_level: ProtectionLevel::Hsm.into(),
+        };
+        let response = self
+            .inner_client()
+            .generate_random_bytes(request, None)
+            .await
+            .inspect_err(|error| {
+                logger::error!(gcp_kms_err = ?error, "Failed to GCP KMS generate random bytes");
+            })
+            .change_context(errors::CryptoError::KeyGeneration)?;
+
+        let key = <[u8; 32]>::try_from(response.data)
+            .map_err(|_| errors::CryptoError::KeyGeneration.into_report())?;
+
+        Ok((Source::GcpKms, key.into()))
+    }
+
+    fn encrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
+        Box::pin(async move {
+            let request = EncryptRequest {
+                name: self.key_name().to_owned(),
+                plaintext: input.peek().to_vec(),
+                additional_authenticated_data: Vec::new(),
+                plaintext_crc32c: None,
+                additional_authenticated_data_crc32c: None,
+            };
+            let response = self
+                .inner_client()
+                .encrypt(request, None)
+                .await
+                .inspect_err(|error| {
+                    logger::error!(gcp_kms_err = ?error, "Failed to GCP KMS encrypt data");
+                })
+                .change_context(errors::CryptoError::EncryptionFailed("GCP KMS"))?;
+
+            Ok(response.ciphertext.into())
+        })
+    }
+
+    fn decrypt(&self, input: StrongSecret<Vec<u8>>) -> Self::DataReturn<'_> {
+        Box::pin(async move {
+            let request = DecryptRequest {
+                name: self.key_name().to_owned(),
+                ciphertext: input.peek().to_vec(),
+                additional_authenticated_data: Vec::new(),
+                ciphertext_crc32c: None,
+                additional_authenticated_data_crc32c: None,
+            };
+            let response = self
+                .inner_client()
+                .decrypt(request, None)
+                .await
+                .inspect_err(|error| {
+                    logger::error!(gcp_kms_err = ?error, "Failed to GCP KMS decrypt data");
+                })
+                .change_context(errors::CryptoError::DecryptionFailed("GCP KMS"))?;
+
+            Ok(response.plaintext.into())
+        })
+    }
+}

--- a/src/crypto/vault.rs
+++ b/src/crypto/vault.rs
@@ -26,6 +26,32 @@ pub struct VaultSettings {
     pub vault_token: hyperswitch_masking::Secret<String>,
 }
 
+impl VaultSettings {
+    /// All four fields are required to authenticate and address the transit engine.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        let fields = [
+            (self.url.as_str(), "Vault URL must not be empty"),
+            (
+                self.mount_point.as_str(),
+                "Vault mount point must not be empty",
+            ),
+            (
+                self.encryption_key.as_str(),
+                "Vault encryption key must not be empty",
+            ),
+            (
+                self.vault_token.peek().as_str(),
+                "Vault token must not be empty",
+            ),
+        ];
+
+        fields
+            .into_iter()
+            .find(|(value, _)| value.trim().is_empty())
+            .map_or(Ok(()), |(_, error)| Err(error))
+    }
+}
+
 pub struct Vault {
     inner_client: VaultClient,
     settings: VaultSettings,
@@ -46,6 +72,29 @@ impl Vault {
             inner_client: client,
             settings,
         }
+    }
+
+    /// Decrypts `data` (already in Vault's own transit ciphertext format, not base64) via
+    /// HashiCorp Vault. Used for bootstrap secrets read from TOML config.
+    pub async fn decrypt_secret(&self, data: &str) -> CustomResult<String, errors::CryptoError> {
+        let b64_encoded_str = transit::data::decrypt(
+            &self.inner_client,
+            &self.settings.mount_point,
+            &self.settings.encryption_key,
+            data,
+            None,
+        )
+        .await
+        .change_context(CryptoError::DecryptionFailed("HashiCorp Vault"))?
+        .plaintext;
+
+        let decoded = BASE64_ENGINE
+            .decode(b64_encoded_str)
+            .change_context(CryptoError::DecryptionFailed("HashiCorp Vault"))?;
+
+        String::from_utf8(decoded).change_context(CryptoError::ParseError(
+            "Invalid HashiCorp Vault decrypted secret".to_string(),
+        ))
     }
 }
 

--- a/src/env/metrics.rs
+++ b/src/env/metrics.rs
@@ -281,7 +281,11 @@ macro_rules! impl_metric_value_from {
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum KeyManagerBackend {
+    #[cfg(feature = "aws")]
     AwsKms,
+    #[cfg(feature = "gcp")]
+    GcpKms,
+    #[cfg(feature = "vault")]
     Vault,
     Aes256,
 }

--- a/src/errors/crypto.rs
+++ b/src/errors/crypto.rs
@@ -1,5 +1,6 @@
 use error_stack::{IntoReport, ResultExt};
 
+#[cfg(feature = "aws")]
 use crate::env::observability as logger;
 
 #[derive(Debug, thiserror::Error)]
@@ -18,6 +19,8 @@ pub enum CryptoError {
     ParseError(String),
     #[error("Invalid value")]
     InvalidValue,
+    #[error("Failed to create the key management client")]
+    ClientCreationFailed,
 }
 
 impl super::SwitchError<(), CryptoError> for Result<(), ring::error::Unspecified> {
@@ -47,6 +50,7 @@ impl<T> super::SwitchError<T, CryptoError> for Result<T, strum::ParseError> {
     }
 }
 
+#[cfg(feature = "aws")]
 impl<T, U: core::fmt::Debug> super::SwitchError<T, CryptoError>
     for Result<T, aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::encrypt::EncryptError, U>>
 {
@@ -58,6 +62,7 @@ impl<T, U: core::fmt::Debug> super::SwitchError<T, CryptoError>
     }
 }
 
+#[cfg(feature = "aws")]
 impl<T, U: core::fmt::Debug> super::SwitchError<T, CryptoError>
     for Result<T, aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::decrypt::DecryptError, U>>
 {
@@ -69,6 +74,7 @@ impl<T, U: core::fmt::Debug> super::SwitchError<T, CryptoError>
     }
 }
 
+#[cfg(feature = "aws")]
 impl<T, U: core::fmt::Debug> super::SwitchError<T, CryptoError>
     for Result<
         T,

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,1 +1,4 @@
+#[cfg(feature = "aws")]
 pub(crate) mod aws;
+#[cfg(feature = "gcp")]
+pub(crate) mod gcp;

--- a/src/services/aws.rs
+++ b/src/services/aws.rs
@@ -1,3 +1,3 @@
 mod config;
 
-pub use config::*;
+pub use config::{AwsKmsClient, AwsKmsConfig};

--- a/src/services/aws/config.rs
+++ b/src/services/aws/config.rs
@@ -73,14 +73,14 @@ impl AwsKmsClient {
         &self,
         data: impl AsRef<[u8]>,
     ) -> CustomResult<String, errors::CryptoError> {
-        let plaintext_blob_data = crate::consts::base64::BASE64_ENGINE
+        let ciphertext_blob_data = crate::consts::base64::BASE64_ENGINE
             .decode(data)
             .change_context(errors::CryptoError::ParseError(
                 "Failed to base64 decode AWS KMS ciphertext".to_string(),
             ))?;
 
-        let plaintext_blob = Blob::new(plaintext_blob_data);
-        let mut decrypt_request = self.inner_client.decrypt().ciphertext_blob(plaintext_blob);
+        let ciphertext_blob = Blob::new(ciphertext_blob_data);
+        let mut decrypt_request = self.inner_client.decrypt().ciphertext_blob(ciphertext_blob);
 
         if !self.skip_key_id_on_decrypt {
             decrypt_request = decrypt_request.key_id(&self.key_id);

--- a/src/services/aws/config.rs
+++ b/src/services/aws/config.rs
@@ -1,5 +1,9 @@
 use aws_config::{BehaviorVersion, meta::region::RegionProviderChain};
-use aws_sdk_kms::{Client, config::Region};
+use aws_sdk_kms::{Client, config::Region, primitives::Blob};
+use base64::Engine;
+use error_stack::{IntoReport, ResultExt};
+
+use crate::errors::{self, CustomResult, SwitchError};
 
 /// Configuration parameters required for constructing a [`AwsKmsClient`].
 #[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq)]
@@ -13,6 +17,19 @@ pub struct AwsKmsConfig {
 
     /// When true, omits key_id from decryption requests, allowing KMS to determine the key from ciphertext metadata.
     pub skip_key_id_on_decrypt: bool,
+}
+
+impl AwsKmsConfig {
+    /// Both `key_id` and `region` are required to send KMS requests.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.key_id.trim().is_empty() {
+            return Err("AWS KMS key ID must not be empty");
+        }
+        if self.region.trim().is_empty() {
+            return Err("AWS KMS region must not be empty");
+        }
+        Ok(())
+    }
 }
 
 /// Client for AWS KMS operations.
@@ -48,5 +65,36 @@ impl AwsKmsClient {
 
     pub fn skip_key_id_on_decrypt(&self) -> bool {
         self.skip_key_id_on_decrypt
+    }
+
+    /// Decrypts base64-encoded `data` via AWS KMS. Used for bootstrap secrets read from
+    /// TOML config.
+    pub async fn decrypt_secret(
+        &self,
+        data: impl AsRef<[u8]>,
+    ) -> CustomResult<String, errors::CryptoError> {
+        let plaintext_blob_data = crate::consts::base64::BASE64_ENGINE
+            .decode(data)
+            .change_context(errors::CryptoError::ParseError(
+                "Failed to base64 decode AWS KMS ciphertext".to_string(),
+            ))?;
+
+        let plaintext_blob = Blob::new(plaintext_blob_data);
+        let mut decrypt_request = self.inner_client.decrypt().ciphertext_blob(plaintext_blob);
+
+        if !self.skip_key_id_on_decrypt {
+            decrypt_request = decrypt_request.key_id(&self.key_id);
+        }
+
+        let decrypted_output = decrypt_request.send().await.switch()?;
+
+        let plaintext = decrypted_output
+            .plaintext
+            .ok_or(errors::CryptoError::DecryptionFailed("KMS").into_report())?
+            .into_inner();
+
+        String::from_utf8(plaintext).change_context(errors::CryptoError::ParseError(
+            "Invalid AWS KMS decrypted secret".to_string(),
+        ))
     }
 }

--- a/src/services/gcp.rs
+++ b/src/services/gcp.rs
@@ -1,0 +1,3 @@
+mod config;
+
+pub use config::*;

--- a/src/services/gcp.rs
+++ b/src/services/gcp.rs
@@ -1,3 +1,3 @@
 mod config;
 
-pub use config::*;
+pub use config::{GcpKmsClient, GcpKmsConfig};

--- a/src/services/gcp/config.rs
+++ b/src/services/gcp/config.rs
@@ -1,5 +1,9 @@
+use base64::Engine;
 use error_stack::ResultExt;
-use google_cloud_kms::client::{Client, ClientConfig};
+use google_cloud_kms::{
+    client::{Client, ClientConfig},
+    grpc::kms::v1::DecryptRequest,
+};
 
 use crate::errors::{self, CustomResult};
 
@@ -90,5 +94,37 @@ impl GcpKmsClient {
 
     pub fn location(&self) -> &str {
         &self.location
+    }
+
+    /// Decrypts base64-encoded `data` via GCP Cloud KMS. Used for bootstrap secrets read
+    /// from TOML config.
+    pub async fn decrypt_secret(
+        &self,
+        data: impl AsRef<[u8]>,
+    ) -> CustomResult<String, errors::CryptoError> {
+        let ciphertext = crate::consts::base64::BASE64_ENGINE
+            .decode(data)
+            .change_context(errors::CryptoError::ParseError(
+                "Failed to base64 decode GCP KMS ciphertext".to_string(),
+            ))?;
+
+        let request = DecryptRequest {
+            name: self.key_name.clone(),
+            ciphertext,
+            additional_authenticated_data: Vec::new(),
+            ciphertext_crc32c: None,
+            additional_authenticated_data_crc32c: None,
+        };
+
+        let plaintext = self
+            .inner_client
+            .decrypt(request, None)
+            .await
+            .change_context(errors::CryptoError::DecryptionFailed("GCP KMS"))?
+            .plaintext;
+
+        String::from_utf8(plaintext).change_context(errors::CryptoError::ParseError(
+            "Invalid GCP KMS decrypted secret".to_string(),
+        ))
     }
 }

--- a/src/services/gcp/config.rs
+++ b/src/services/gcp/config.rs
@@ -1,0 +1,94 @@
+use error_stack::ResultExt;
+use google_cloud_kms::client::{Client, ClientConfig};
+
+use crate::errors::{self, CustomResult};
+
+/// Configuration parameters required for constructing a [`GcpKmsClient`].
+#[derive(Clone, Debug, Default, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct GcpKmsConfig {
+    /// The GCP project ID that owns the KMS key ring.
+    pub project_id: String,
+
+    /// The location ID (e.g. `"global"`, `"us-east1"`) of the KMS key ring.
+    pub location_id: String,
+
+    /// The ID of the KMS key ring.
+    pub key_ring_id: String,
+
+    /// The ID of the KMS key used to encrypt or decrypt data.
+    pub key_id: String,
+}
+
+impl GcpKmsConfig {
+    /// All four fields are required to build the full KMS resource path.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.project_id.trim().is_empty() {
+            return Err("GCP KMS project ID must not be empty");
+        }
+        if self.location_id.trim().is_empty() {
+            return Err("GCP KMS location ID must not be empty");
+        }
+        if self.key_ring_id.trim().is_empty() {
+            return Err("GCP KMS key ring ID must not be empty");
+        }
+        if self.key_id.trim().is_empty() {
+            return Err("GCP KMS key ID must not be empty");
+        }
+        Ok(())
+    }
+}
+
+/// Client for GCP Cloud KMS operations.
+#[derive(Clone)]
+pub struct GcpKmsClient {
+    inner_client: Client,
+    key_name: String,
+    location: String,
+}
+
+impl std::fmt::Debug for GcpKmsClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcpKmsClient")
+            .field("key_name", &self.key_name)
+            .field("location", &self.location)
+            .finish()
+    }
+}
+
+impl GcpKmsClient {
+    /// Authenticates via Application Default Credentials.
+    pub async fn new(config: &GcpKmsConfig) -> CustomResult<Self, errors::CryptoError> {
+        let client_config = ClientConfig::default()
+            .with_auth()
+            .await
+            .change_context(errors::CryptoError::ClientCreationFailed)?;
+        let inner_client = Client::new(client_config)
+            .await
+            .change_context(errors::CryptoError::ClientCreationFailed)?;
+
+        Ok(Self {
+            inner_client,
+            key_name: format!(
+                "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}",
+                config.project_id, config.location_id, config.key_ring_id, config.key_id
+            ),
+            location: format!(
+                "projects/{}/locations/{}",
+                config.project_id, config.location_id
+            ),
+        })
+    }
+
+    pub fn inner_client(&self) -> &Client {
+        &self.inner_client
+    }
+
+    pub fn key_name(&self) -> &str {
+        &self.key_name
+    }
+
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **GCP Cloud KMS** as a third key-management backend alongside AWS KMS and HashiCorp Vault. `src/crypto/gcp.rs` implements the `Crypto` trait directly against the `google-cloud-kms` SDK, mirroring `src/crypto/aws.rs`'s shape exactly (inline SDK calls, no intermediate abstraction) — `src/services/gcp/config.rs` is a thin config + client holder, same role as `src/services/aws/config.rs`.
- Backend selection moves from a compile-time-flag-driven `cfg!()` precedence chain to a **config-driven runtime toggle**: `secrets.manager = "aws_kms" | "gcp_kms" | "hashicorp_vault" | "aes_local"` in TOML, mirroring `hyperswitch`/`hyperswitch-card-vault`'s `SecretsManagementConfig` pattern. `aws`/`vault`/`gcp` are now real optional-dependency feature gates, so any combination can ship in one binary and config decides which backend runs at startup.
- `Secrets::create_keymanager_client` now returns a `Result` and propagates client-construction failure with `?`, instead of panicking internally — matching hyperswitch's own `get_encryption_management_client` (`crates/external_services/src/managers/encryption_management.rs`). The panic boundary moved to the actual boot call site in `SessionState::from_config` (`src/app.rs`), which already panicked there for thread-pool build failures.
- `src/crypto/kms.rs` renamed to `src/crypto/aws.rs` — "kms" was ambiguous once GCP KMS existed too; matches `src/crypto/gcp.rs`'s naming.
- New `docs/encryption-key-management-flow.md`: the two-layer architecture (bootstrap secrets vs. live DEK management), why cripta uses one trait pair instead of hyperswitch's two, the envelope-encryption data flow, a backend comparison table, and an extension checklist for adding a future backend.
- `config/development.toml` currently points `secrets.manager` at a real AWS KMS key (account `143555788000`, region `ap-south-1`) with the DB password re-encrypted as AWS KMS ciphertext; `aes_local` is left commented as a credential-free fallback. A GCP KMS dev key was also configured and fully verified earlier in development before switching the committed example to AWS.
- `config/development.toml` and `config/config.example.toml` both document (commented out by default) a `filtering_directive` required when `manager = "aws_kms"` — see "Notes for reviewers" below.

## Test Plan

- [x] `cargo hack check --each-feature --all-targets` — clean on stable and MSRV 1.92.0
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test --all-features` — passes
- [x] `cargo +nightly fmt --all --check` — clean
- [x] Live end-to-end round trip against a real **GCP KMS** dev key: app boot, `POST /key/create` → `POST /data/encrypt` → `POST /data/decrypt`, confirmed `data_key_store.source = GcpKms`
- [x] Live end-to-end round trip against a real **AWS KMS** key (via SSO-assumed-role credentials): same flow, confirmed `data_key_store.source = KMS`
 
 
 ### for aws 
<img width="2060" height="1028" alt="Screenshot 2026-08-31 at 12 14 38 PM" src="https://github.com/user-attachments/assets/999a71a6-0d7b-4b5d-9e6b-4301e7aadc95" />
<img width="1643" height="828" alt="Screenshot 2026-08-31 at 12 13 34 PM" src="https://github.com/user-attachments/assets/e1092dcb-6287-4518-a9cf-4fcc9a0a0c56" />

### for Gcp
<img width="2025" height="206" alt="Screenshot 2026-08-31 at 2 38 58 PM" src="https://github.com/user-attachments/assets/833d8a40-c785-47d7-8a89-d194a39f0a40" />
<img width="2043" height="334" alt="Screenshot 2026-08-31 at 2 39 47 PM" src="https://github.com/user-attachments/assets/3faf2511-ca4c-4d3e-8d3e-ba6de8ca783b" />
<img width="2077" height="448" alt="Screenshot 2026-08-31 at 2 40 00 PM" src="https://github.com/user-attachments/assets/d9481685-1728-4e33-8e5d-35874bb6cb91" />
<img width="2034" height="318" alt="Screenshot 2026-08-31 at 2 40 15 PM" src="https://github.com/user-attachments/assets/81b3d6f6-c5df-4781-959c-c74eb4f26393" />
